### PR TITLE
ci: trigger playwright workflow on repository_dispatch

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -5,6 +5,8 @@ on:
         branches: [main, master]
     pull_request:
         branches: [main, master]
+    repository_dispatch:
+        types: [e2e-test]
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
In order to test triggering the Playwright tests workflow from the `im-manager` repo, we need to add the `repository_dispatch` event as a trigger.