### PR TITLE
feat: link to pgadmin in details page

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,1 +1,9 @@
+import { Dhis2StackName } from './views/instances/new-dhis2/parameter-fieldset'
+
+export const STACK_NAMES: Record<string, Dhis2StackName> = {
+    DB: 'dhis2-db',
+    CORE: 'dhis2-core',
+    PG_ADMIN: 'pgadmin',
+}
+
 export const VIEWABLE_INSTANCE_TYPES = ['pgadmin', 'dhis2-core']

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,1 @@
+export const VIEWABLE_INSTANCE_TYPES = ['pgadmin', 'dhis2-core']

--- a/src/views/instances/details/actions-dropdown-menu.tsx
+++ b/src/views/instances/details/actions-dropdown-menu.tsx
@@ -8,15 +8,12 @@ import { ResetMenuItem } from './reset-menu-item'
 import { RestartMenuItem } from './restart-menu-item'
 import { SaveAsMenuItem } from './save-as-menu-item'
 import { Dhis2StackName } from '../new-dhis2/parameter-fieldset'
-import { ViewInstanceMenuItem } from './view-instance-menu-item'
 
 type ActionsDropdownMenuProps = {
     deploymentId: number
     instanceId: number
     stackName: Dhis2StackName
     refetch: RefetchFunction<any, Deployment>
-    groupName: string
-    name: string
 }
 type OnActionCompletFn = (shouldRefetch?: boolean) => void
 export type AsyncActionProps = {
@@ -27,7 +24,7 @@ export type AsyncActionProps = {
     onComplete: OnActionCompletFn
 }
 
-export const ActionsDropdownMenu = ({ deploymentId, instanceId, stackName, refetch, groupName, name }: ActionsDropdownMenuProps) => {
+export const ActionsDropdownMenu = ({ deploymentId, instanceId, stackName, refetch }: ActionsDropdownMenuProps) => {
     const anchor = useRef()
     const [open, setOpen] = useState(false)
     const [loading, setLoading] = useState(false)
@@ -56,7 +53,6 @@ export const ActionsDropdownMenu = ({ deploymentId, instanceId, stackName, refet
             {open && (
                 <Popover onClickOutside={togglePopover} reference={anchor} placement="bottom-start">
                     <Menu>
-                        {stackName !== 'dhis2-db' && <ViewInstanceMenuItem groupName={groupName} name={name} stackName={stackName} />}
                         <LogMenuItem instanceId={instanceId} stackName={stackName} />
                         {stackName === 'dhis2-db' && <SaveAsMenuItem instanceId={instanceId} stackName={stackName} onComplete={onComplete} onStart={onStart} />}
                         <RestartMenuItem instanceId={instanceId} stackName={stackName} onComplete={onComplete} onStart={onStart} />

--- a/src/views/instances/details/actions-dropdown-menu.tsx
+++ b/src/views/instances/details/actions-dropdown-menu.tsx
@@ -8,12 +8,15 @@ import { ResetMenuItem } from './reset-menu-item'
 import { RestartMenuItem } from './restart-menu-item'
 import { SaveAsMenuItem } from './save-as-menu-item'
 import { Dhis2StackName } from '../new-dhis2/parameter-fieldset'
+import { ViewInstanceMenuItem } from './view-instance-menu-item'
 
 type ActionsDropdownMenuProps = {
     deploymentId: number
     instanceId: number
     stackName: Dhis2StackName
     refetch: RefetchFunction<any, Deployment>
+    groupName: string
+    name: string
 }
 type OnActionCompletFn = (shouldRefetch?: boolean) => void
 export type AsyncActionProps = {
@@ -24,7 +27,7 @@ export type AsyncActionProps = {
     onComplete: OnActionCompletFn
 }
 
-export const ActionsDropdownMenu = ({ deploymentId, instanceId, stackName, refetch }: ActionsDropdownMenuProps) => {
+export const ActionsDropdownMenu = ({ deploymentId, instanceId, stackName, refetch, groupName, name }: ActionsDropdownMenuProps) => {
     const anchor = useRef()
     const [open, setOpen] = useState(false)
     const [loading, setLoading] = useState(false)
@@ -53,6 +56,7 @@ export const ActionsDropdownMenu = ({ deploymentId, instanceId, stackName, refet
             {open && (
                 <Popover onClickOutside={togglePopover} reference={anchor} placement="bottom-start">
                     <Menu>
+                        {stackName === 'pgadmin' && <ViewInstanceMenuItem groupName={groupName} name={name} stackName={stackName} />}
                         <LogMenuItem instanceId={instanceId} stackName={stackName} />
                         {stackName === 'dhis2-db' && <SaveAsMenuItem instanceId={instanceId} stackName={stackName} onComplete={onComplete} onStart={onStart} />}
                         <RestartMenuItem instanceId={instanceId} stackName={stackName} onComplete={onComplete} onStart={onStart} />

--- a/src/views/instances/details/actions-dropdown-menu.tsx
+++ b/src/views/instances/details/actions-dropdown-menu.tsx
@@ -56,7 +56,7 @@ export const ActionsDropdownMenu = ({ deploymentId, instanceId, stackName, refet
             {open && (
                 <Popover onClickOutside={togglePopover} reference={anchor} placement="bottom-start">
                     <Menu>
-                        {stackName === 'pgadmin' && <ViewInstanceMenuItem groupName={groupName} name={name} stackName={stackName} />}
+                        {stackName !== 'dhis2-db' && <ViewInstanceMenuItem groupName={groupName} name={name} stackName={stackName} />}
                         <LogMenuItem instanceId={instanceId} stackName={stackName} />
                         {stackName === 'dhis2-db' && <SaveAsMenuItem instanceId={instanceId} stackName={stackName} onComplete={onComplete} onStart={onStart} />}
                         <RestartMenuItem instanceId={instanceId} stackName={stackName} onComplete={onComplete} onStart={onStart} />

--- a/src/views/instances/details/deployment-instances-list.tsx
+++ b/src/views/instances/details/deployment-instances-list.tsx
@@ -6,6 +6,8 @@ import { ActionsDropdownMenu } from './actions-dropdown-menu'
 import { Deployment, DeploymentInstance } from '../../../types'
 import { RefetchFunction } from 'axios-hooks'
 import { Dhis2StackName } from '../new-dhis2/parameter-fieldset'
+import { ViewInstanceMenuItem } from './view-instance-menu-item'
+import { VIEWABLE_INSTANCE_TYPES } from '../../../constants'
 
 export const DeploymentInstancesList: FC<{
     deploymentId: number
@@ -20,6 +22,7 @@ export const DeploymentInstancesList: FC<{
                 <DataTableColumnHeader>Type</DataTableColumnHeader>
                 <DataTableColumnHeader>Created</DataTableColumnHeader>
                 <DataTableColumnHeader>Updated</DataTableColumnHeader>
+                <DataTableColumnHeader></DataTableColumnHeader>
                 <DataTableColumnHeader></DataTableColumnHeader>
             </DataTableRow>
         </DataTableHead>
@@ -37,13 +40,20 @@ export const DeploymentInstancesList: FC<{
                         <Moment date={instance.updatedAt} fromNow />
                     </DataTableCell>
                     <DataTableCell staticStyle align="right">
+                        {VIEWABLE_INSTANCE_TYPES.includes(instance.stackName) && (
+                            <ViewInstanceMenuItem
+                                groupName={instance.groupName}
+                                name={instance.name}
+                                stackName={instance.stackName as Dhis2StackName}
+                            />
+                        )}
+                    </DataTableCell>
+                    <DataTableCell staticStyle align="right">
                         <ActionsDropdownMenu
                             deploymentId={deploymentId}
                             instanceId={instance.id}
                             stackName={instance.stackName as Dhis2StackName}
                             refetch={refetch}
-                            groupName={instance.groupName}
-                            name={instance.name}
                         />
                     </DataTableCell>
                 </DataTableRow>

--- a/src/views/instances/details/deployment-instances-list.tsx
+++ b/src/views/instances/details/deployment-instances-list.tsx
@@ -37,7 +37,14 @@ export const DeploymentInstancesList: FC<{
                         <Moment date={instance.updatedAt} fromNow />
                     </DataTableCell>
                     <DataTableCell staticStyle align="right">
-                        <ActionsDropdownMenu deploymentId={deploymentId} instanceId={instance.id} stackName={instance.stackName as Dhis2StackName} refetch={refetch} />
+                        <ActionsDropdownMenu
+                            deploymentId={deploymentId}
+                            instanceId={instance.id}
+                            stackName={instance.stackName as Dhis2StackName}
+                            refetch={refetch}
+                            groupName={instance.groupName}
+                            name={instance.name}
+                        />
                     </DataTableCell>
                 </DataTableRow>
             ))}

--- a/src/views/instances/details/view-instance-menu-item.tsx
+++ b/src/views/instances/details/view-instance-menu-item.tsx
@@ -1,5 +1,6 @@
 import { Button, IconLaunch16 } from '@dhis2/ui'
 import type { FC } from 'react'
+import { STACK_NAMES } from '../../../constants'
 
 type ViewInstanceMenuItemProps = {
     groupName: string
@@ -9,7 +10,7 @@ type ViewInstanceMenuItemProps = {
 
 export const ViewInstanceMenuItem: FC<ViewInstanceMenuItemProps> = ({ groupName, name, stackName }) => {
     const host = `${groupName}.im.dhis2.org`
-    const path = stackName === 'pgadmin' ? `${name}-pgadmin` : name
+    const path = stackName === STACK_NAMES.PG_ADMIN ? `${name}-pgadmin` : name
     const url = `https://${host}/${path}`
 
     return <Button small secondary icon={<IconLaunch16 />} onClick={() => window.open(url, '_blank', 'noopener,noreferrer')}>Open</Button>

--- a/src/views/instances/details/view-instance-menu-item.tsx
+++ b/src/views/instances/details/view-instance-menu-item.tsx
@@ -1,0 +1,26 @@
+import { MenuItem, IconLaunch16 } from '@dhis2/ui'
+import type { FC } from 'react'
+
+type ViewInstanceMenuItemProps = {
+    groupName: string
+    name: string
+    stackName: string
+}
+
+export const ViewInstanceMenuItem: FC<ViewInstanceMenuItemProps> = ({ groupName, name, stackName }) => {
+    const getBaseURL = () => {
+        switch (stackName) {
+            case 'pgadmin':
+                return `${groupName}.im.dhis2.org/${name}-pgadmin`
+            default:
+                return `${groupName}.im.dhis2.org/${name}`
+        }
+    }
+
+    const handleClick = () => {
+        const url = `https://${getBaseURL()}`
+        window.open(url, '_blank', 'noopener,noreferrer')
+    }
+
+    return <MenuItem dense label="Open Instance" icon={<IconLaunch16 />} onClick={handleClick} />
+}

--- a/src/views/instances/details/view-instance-menu-item.tsx
+++ b/src/views/instances/details/view-instance-menu-item.tsx
@@ -1,4 +1,4 @@
-import { MenuItem, IconLaunch16 } from '@dhis2/ui'
+import { Button, IconLaunch16 } from '@dhis2/ui'
 import type { FC } from 'react'
 
 type ViewInstanceMenuItemProps = {
@@ -8,21 +8,9 @@ type ViewInstanceMenuItemProps = {
 }
 
 export const ViewInstanceMenuItem: FC<ViewInstanceMenuItemProps> = ({ groupName, name, stackName }) => {
-    const getBaseURL = () => {
-        switch (stackName) {
-            case 'pgadmin':
-                return `${groupName}.im.dhis2.org/${name}-pgadmin`
-            case 'dhis2-core':
-                return `${groupName}.im.dhis2.org/${name}`
-            default:
-                return `${groupName}.im.dhis2.org/${name}`
-        }
-    }
+    const host = `${groupName}.im.dhis2.org`
+    const path = stackName === 'pgadmin' ? `${name}-pgadmin` : name
+    const url = `https://${host}/${path}`
 
-    const handleClick = () => {
-        const url = `https://${getBaseURL()}`
-        window.open(url, '_blank', 'noopener,noreferrer')
-    }
-
-    return <MenuItem dense label="Open Instance" icon={<IconLaunch16 />} onClick={handleClick} />
+    return <Button small secondary icon={<IconLaunch16 />} onClick={() => window.open(url, '_blank', 'noopener,noreferrer')}>Open</Button>
 }

--- a/src/views/instances/details/view-instance-menu-item.tsx
+++ b/src/views/instances/details/view-instance-menu-item.tsx
@@ -12,6 +12,8 @@ export const ViewInstanceMenuItem: FC<ViewInstanceMenuItemProps> = ({ groupName,
         switch (stackName) {
             case 'pgadmin':
                 return `${groupName}.im.dhis2.org/${name}-pgadmin`
+            case 'dhis2-core':
+                return `${groupName}.im.dhis2.org/${name}`
             default:
                 return `${groupName}.im.dhis2.org/${name}`
         }


### PR DESCRIPTION
Implements [DEVOPS-427](https://dhis2.atlassian.net/browse/DEVOPS-427)
---

### Description
User should be able to view pgadmin instance directly from the instances details page.


https://github.com/user-attachments/assets/d8e48921-6af4-48c9-abc2-bb120a0887b3


https://github.com/user-attachments/assets/89aab72d-7dd2-4939-a911-2abe8ee2966e

---

### Changes
Due to the requests to add an "open"  button to the details lists, this is the updated UI.

<img width="1432" alt="image" src="https://github.com/user-attachments/assets/1f7e99c0-7e4c-41a2-9d9e-9058d564e951">


