### PR TITLE
feat: add account verification success page

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,1 @@
-yarn format
+yarn pre-commit

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
         "e2e": "yarn playwright test --ui",
         "generate-types": "rm -rf ./src/types/generated && yarn openapi --input https://dev.api.im.dhis2.org/swagger.yaml --output ./src/types/generated --client axios --useOptions --useUnionTypes --exportCore false --exportServices false --exportModels true --exportSchemas false && yarn prettier src/types/generated --write --loglevel silent",
         "lint-commit-msg": "npx --no-install commitlint --edit $1",
-        "postinstall": "husky install"
+        "postinstall": "husky install",
+        "pre-commit": "yarn format && yarn lint"
     },
     "dependencies": {
         "@commitlint/cli": "^19.3.0",

--- a/src/app/app.tsx
+++ b/src/app/app.tsx
@@ -9,6 +9,7 @@ import React from 'react'
 import { createBrowserRouter, createRoutesFromElements, Route, RouterProvider } from 'react-router-dom'
 import { Alerts, AuthProvider, ErrorView, Layout } from '../components/index.ts'
 import {
+    AccountVerificationSuccess,
     DatabasesList,
     DeploymentDetails,
     InstancesList,
@@ -31,6 +32,15 @@ const router = createBrowserRouter(
             <Route path="/validate/:token" element={<Validate />} />
             <Route path="/request-password-reset" element={<RequestPasswordReset />} />
             <Route path="/reset-password/:token" element={<ResetPassword />} />
+
+            <Route
+                // allows us to have other routes,
+                // e.g. "/account-verification/expired" when the link has expired
+                path="/account-verification"
+            >
+                <Route path="success" element={<AccountVerificationSuccess />} />
+            </Route>
+
             <Route element={<AuthProvider />}>
                 <Route errorElement={<ErrorView />} path="/" element={<Layout />}>
                     <Route path="/stacks" element={<StacksList />} />

--- a/src/index.css
+++ b/src/index.css
@@ -2,6 +2,12 @@ body {
     background-color: var(--colors-grey100);
 }
 
+#root {
+    height: 100vh;
+    width: 100vw;
+    overflow: auto;
+}
+
 a {
     color: var(--colors-blue600);
 }

--- a/src/views/account-verification/account-verification-success.module.css
+++ b/src/views/account-verification/account-verification-success.module.css
@@ -1,0 +1,16 @@
+.container {
+    max-width: 600px;
+    width: 100%;
+    margin: 80px auto 0;
+}
+
+.headline {
+    font-weight: 400;
+    font-size: 28px;
+    line-height: 40px;
+    margin: 0 0 30px;
+}
+
+.card {
+    padding: 20px;
+}

--- a/src/views/account-verification/account-verification-success.tsx
+++ b/src/views/account-verification/account-verification-success.tsx
@@ -1,0 +1,17 @@
+import { Card, NoticeBox } from '@dhis2/ui'
+import { Link } from 'react-router-dom'
+import classes from './account-verification-success.module.css'
+
+export const AccountVerificationSuccess = () => {
+    return (
+        <div className={classes.container}>
+            <Card className={classes.card}>
+                <h1 className={classes.headline}>Account verification</h1>
+
+                <NoticeBox valid className={classes.successMessage} title="You've successfully activated your account!">
+                    You can log in <Link to="/">here</Link>.
+                </NoticeBox>
+            </Card>
+        </div>
+    )
+}

--- a/src/views/account-verification/index.ts
+++ b/src/views/account-verification/index.ts
@@ -1,0 +1,1 @@
+export { AccountVerificationSuccess } from './account-verification-success.tsx'

--- a/src/views/index.ts
+++ b/src/views/index.ts
@@ -1,3 +1,4 @@
+export * from './account-verification/index.ts'
 export * from './databases/index.ts'
 export * from './instances/index.ts'
 export * from './sign-up/sign-up.tsx'


### PR DESCRIPTION
This will introduce a new static route: `account-verification/success`.
The idea is that we can also use other paths like `account-verification/expired` or `account-verification/failed` if we need those.
But I suppose we can also do that later (yagni) and just use `account-verification-success`?

# Screenshot
![image](https://github.com/user-attachments/assets/5afdf890-d7db-4682-a07f-162b92c2d88a)
