### PR TITLE
Fix/e2e

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
             - "3000:3000"
 
     e2e-test:
-        image: mcr.microsoft.com/playwright:v1.44.1-jammy
+        image: mcr.microsoft.com/playwright:v1.46.0-jammy
         stdin_open: true
         tty: true
         command: sh -c "yarn install --frozen-lockfile && npx playwright test"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     },
     "dependencies": {
         "@commitlint/cli": "^19.3.0",
-        "@dhis2/app-runtime": "^3.10.6",
+        "@dhis2/app-runtime": "^3",
         "@dhis2/app-service-alerts": "^3.10.5",
         "@dhis2/d2-i18n": "^1.1.3",
         "@dhis2/ui": "^9.11.0",
@@ -35,8 +35,8 @@
         "react-router": "^6.24.1",
         "react-router-dom": "^6.26.0",
         "react-scripts": "5.0.1",
-        "styled-jsx": "^5.1.2",
-        "typescript": "^5.4.4",
+        "styled-jsx": "^5.1.6",
+        "typescript": "^5.5.4",
         "web-vitals": "^3.5.2"
     },
     "browserslist": {
@@ -54,7 +54,6 @@
     "devDependencies": {
         "@babel/preset-env": "^7.25.3",
         "@babel/preset-react": "^7.24.7",
-        "@dhis2/app-runtime": "^3",
         "@dhis2/cli-style": "^10.5.1",
         "@ls-lint/ls-lint": "^2.2.2",
         "@playwright/test": "1.46.0",
@@ -81,12 +80,8 @@
         "husky": "^9.1.4",
         "jest": "^29.7.0",
         "openapi-typescript-codegen": "^0.29.0",
-        "playwright": "1.44.1",
-        "playwright-core": "1.45.3",
         "prettier": "^3.3.3",
-        "styled-jsx": "^5.1.6",
         "ts-jest": "^29.2.4",
-        "typescript": "^5.2.2",
         "vite": "^5.3.5"
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2408,7 +2408,7 @@
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2/app-runtime@^3.10.6":
+"@dhis2/app-runtime@^3":
   version "3.10.6"
   resolved "https://registry.yarnpkg.com/@dhis2/app-runtime/-/app-runtime-3.10.6.tgz#10add0b8a2e1de06777e6e78c681a3a8f15ba058"
   integrity sha512-WfC+AHkw0V3V3/wyLPHoTyAf8i4btLl/R2nMBVs3NEXLwA9mekG/gXs7AEPnK2/p6FVoqXMDwJHEH2b8Iw4UFw==
@@ -11083,29 +11083,10 @@ pkg-up@^3.1.0:
   dependencies:
     find-up "^3.0.0"
 
-playwright-core@1.44.1:
-  version "1.44.1"
-  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.44.1.tgz#53ec975503b763af6fc1a7aa995f34bc09ff447c"
-  integrity sha512-wh0JWtYTrhv1+OSsLPgFzGzt67Y7BE/ZS3jEqgGBlp2ppp1ZDj8c+9IARNW4dwf1poq5MgHreEM2KV/GuR4cFA==
-
-playwright-core@1.45.3:
-  version "1.45.3"
-  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.45.3.tgz#e77bc4c78a621b96c3e629027534ee1d25faac93"
-  integrity sha512-+ym0jNbcjikaOwwSZycFbwkWgfruWvYlJfThKYAlImbxUgdWFO2oW70ojPm4OpE4t6TAo2FY/smM+hpVTtkhDA==
-
 playwright-core@1.46.0:
   version "1.46.0"
   resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.46.0.tgz#2336ac453a943abf0dc95a76c117f9d3ebd390eb"
   integrity sha512-9Y/d5UIwuJk8t3+lhmMSAJyNP1BUC/DqP3cQJDQQL/oWqAiuPTLgy7Q5dzglmTLwcBRdetzgNM/gni7ckfTr6A==
-
-playwright@1.44.1:
-  version "1.44.1"
-  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.44.1.tgz#5634369d777111c1eea9180430b7a184028e7892"
-  integrity sha512-qr/0UJ5CFAtloI3avF95Y0L1xQo6r3LQArLIg/z/PoGJ6xa+EwzrwO5lpNr/09STxdHuUoP2mvuELJS+hLdtgg==
-  dependencies:
-    playwright-core "1.44.1"
-  optionalDependencies:
-    fsevents "2.3.2"
 
 playwright@1.46.0:
   version "1.46.0"
@@ -13243,7 +13224,7 @@ style-loader@^3.3.1:
   resolved "https://registry.yarnpkg.com/style-loader/-/style-loader-3.3.4.tgz#f30f786c36db03a45cbd55b6a70d930c479090e7"
   integrity sha512-0WqXzrsMTyb8yjZJHDqwmnwRJvhALK9LfRtRc6B4UTWe8AijYLZYZ9thuJTZc2VfQWINADW/j+LiJnfy2RoC1w==
 
-styled-jsx@^5.1.2:
+styled-jsx@^5.1.6:
   version "5.1.6"
   resolved "https://registry.yarnpkg.com/styled-jsx/-/styled-jsx-5.1.6.tgz#83b90c077e6c6a80f7f5e8781d0f311b2fe41499"
   integrity sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==
@@ -13844,7 +13825,7 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typescript@^5.4.4:
+typescript@^5.5.4:
   version "5.5.4"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.5.4.tgz#d9852d6c82bad2d2eda4fd74a5762a8f5909e9ba"
   integrity sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==


### PR DESCRIPTION
The e2e tests where failing as seen [here](https://github.com/dhis2-sre/im-web-client/actions/runs/10281211060/job/28450252968). It seems to be due to some colliding versions in the package.json file.