### PR TITLE
test: only use the Database select filter if more than 7 dbs

### DIFF
--- a/e2e/instances.spec.ts
+++ b/e2e/instances.spec.ts
@@ -37,7 +37,7 @@ test.describe('new instance', () => {
         await page.getByTestId('dhis2-uiwidgets-singleselectfield').filter({ hasText: 'Database' }).getByTestId('dhis2-uicore-select-input').click()
 
         // If there are more than 7 databases uploaded, we need to interact with the conditional #filter field.
-        const numberOfDatabases = await page.$$eval('[data-test="dhis2-uicore-singleselectoption"]', (options) => options.length)
+        const numberOfDatabases = await page.getByTestId('dhis2-uicore-singleselectoption').count()
         if (numberOfDatabases > 7) {
             await page.locator('#filter').fill(dbFileName)
         }

--- a/e2e/instances.spec.ts
+++ b/e2e/instances.spec.ts
@@ -35,7 +35,12 @@ test.describe('new instance', () => {
         await page.getByRole('textbox', { name: 'Description' }).fill('This is an e2e test instance.')
 
         await page.getByTestId('dhis2-uiwidgets-singleselectfield').filter({ hasText: 'Database' }).getByTestId('dhis2-uicore-select-input').click()
-        await page.locator('#filter').fill(dbFileName)
+
+        // If there are more than 7 databases uploaded, we need to interact with the conditional #filter field.
+        const numberOfDatabases = await page.$$eval('[data-test="dhis2-uicore-singleselectoption"]', (options) => options.length)
+        if (numberOfDatabases > 7) {
+            await page.locator('#filter').fill(dbFileName)
+        }
         await page.getByText(dbFileName).click()
 
         await expect(page.getByRole('button', { name: 'Create instance' })).toBeEnabled()


### PR DESCRIPTION
The changes have been tested via https://github.com/dhis2-sre/im-manager/pull/908 ([e2e tests run](https://github.com/dhis2-sre/im-manager/actions/runs/11110706480/job/30869021921)), so that the targeted API_URL is of a new PR instance with no other DBs uploaded besides the one for the test, as well as the current PR.  i.e. the tests are passing for both cases - when there are both more and less than 7 options.