### PR TITLE
feat: show lock icon for sensitive parameter values

### DIFF
--- a/src/types/generated/models/StackParameter.ts
+++ b/src/types/generated/models/StackParameter.ts
@@ -8,4 +8,5 @@ export type StackParameter = {
     displayName?: string
     parameterName?: string
     priority?: number
+    sensitive?: boolean
 }

--- a/src/views/instances/details/instance-details.tsx
+++ b/src/views/instances/details/instance-details.tsx
@@ -1,20 +1,28 @@
-import { Button, Card, Center, CircularLoader, DataTable, DataTableBody, DataTableCell, DataTableColumnHeader, DataTableHead, DataTableRow } from '@dhis2/ui'
+import { useAlert } from '@dhis2/app-service-alerts'
+import { Button, Card, Center, CircularLoader, DataTable, DataTableBody, DataTableCell, DataTableColumnHeader, DataTableHead, DataTableRow, IconLock16 } from '@dhis2/ui'
 import type { AxiosResponse } from 'axios'
 import { useCallback, useEffect, useState } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 import { Heading } from '../../../components/index.ts'
 import { useAuthAxios } from '../../../hooks/index.ts'
-import { DeploymentInstance } from '../../../types/index.ts'
+import { DeploymentInstance, Stack, StackParameter } from '../../../types/index.ts'
 import styles from '../list/instances-list.module.css'
 import { InstanceSummary } from './instance-summary.tsx'
 
 export const InstanceDetails = () => {
+    const { show: showAlert } = useAlert(
+        ({ message }) => message,
+        ({ isCritical }) => (isCritical ? { critical: true } : { success: true })
+    )
     const navigate = useNavigate()
     const { id } = useParams()
     const [instance, setInstance] = useState<DeploymentInstance>()
     const [isDecrypted, setIsDecrypted] = useState<boolean>()
+    const [stackParameters, setStackParameters] = useState<Stack>(null)
     const [{ data, loading: loadingDetails }, instanceDetails] = useAuthAxios<DeploymentInstance>({ url: `/instances/${id}/details` })
     const [{ loading: loadingDecryptedDetails }, instanceDecryptedDetails] = useAuthAxios<DeploymentInstance>({ url: `/instances/${id}/decrypted-details` }, { manual: true })
+    const [{ loading: loadingStack }, fetchStack] = useAuthAxios<Stack>({ method: 'GET' }, { manual: true })
+
     const toggleEncryption = useCallback(async () => {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         let response: AxiosResponse<DeploymentInstance, any>
@@ -25,21 +33,34 @@ export const InstanceDetails = () => {
         }
 
         if (response.status === 400) {
-            // TODO: Notification... Only owner, group admin or admin can decrypt
-            console.log(400)
+            showAlert({ message: 'Access denied!', isCritical: true })
+            return
         }
 
         if (response.status === 200) {
             setInstance(response.data)
             setIsDecrypted(!isDecrypted)
         }
-    }, [instanceDecryptedDetails, instanceDetails, isDecrypted])
+    }, [instanceDecryptedDetails, instanceDetails, isDecrypted, showAlert])
+
+    const fetchStackCallback = useCallback(async () => {
+        const response = await fetchStack({ url: `/stacks/${data.stackName}` })
+        const stackParametersMap = response.data.parameters.reduce(
+            (map, parameter) => {
+                map[parameter.parameterName] = parameter
+                return map
+            },
+            {} as Record<number, StackParameter>
+        )
+        setStackParameters(stackParametersMap)
+    }, [data, fetchStack])
 
     useEffect(() => {
         setInstance(data)
-    }, [data])
+        void fetchStackCallback()
+    }, [data, fetchStackCallback])
 
-    if (loadingDetails || loadingDecryptedDetails || !instance) {
+    if (loadingDetails || loadingDecryptedDetails || loadingStack || !instance || !stackParameters) {
         return (
             <Center className={styles.loaderWrap}>
                 <CircularLoader />
@@ -69,7 +90,19 @@ export const InstanceDetails = () => {
                     {Object.keys(instance.parameters).map((name) => (
                         <DataTableRow key={name}>
                             <DataTableCell staticStyle>{name}</DataTableCell>
-                            <DataTableCell staticStyle>{instance.parameters[name].value}</DataTableCell>
+                            <DataTableCell staticStyle>
+                                {stackParameters[name].sensitive && (
+                                    <span>
+                                        {isDecrypted && instance.parameters[name].value}
+                                        {!isDecrypted && (
+                                            <Button onClick={toggleEncryption} title={'Decrypt parameter'}>
+                                                <IconLock16 />
+                                            </Button>
+                                        )}
+                                    </span>
+                                )}
+                                {!stackParameters[name].sensitive && instance.parameters[name].value}
+                            </DataTableCell>
                         </DataTableRow>
                     ))}
                 </DataTableBody>

--- a/src/views/instances/details/instance-summary.tsx
+++ b/src/views/instances/details/instance-summary.tsx
@@ -23,7 +23,7 @@ export const InstanceSummary: FC<InstanceSummaryProps> = ({ instance, toggleEncr
         <div className={styles.wrapper}>
             <h2 className={styles.title}>
                 {instance.name}&nbsp;&nbsp;
-                <Button onClick={toggleEncryption} disabled={isDecrypted && canDecrypt}>
+                <Button onClick={toggleEncryption} disabled={isDecrypted && canDecrypt} title={(isDecrypted ? 'Encrypt' : 'Decrypt') + ' parameters'}>
                     {!isDecrypted && <IconLock16 />}
                     {isDecrypted && <IconLockOpen16 />}
                 </Button>


### PR DESCRIPTION
The goal of this PR is to show a lock icon next to each sensitive parameter on the details view.

Local testing can be done using the below backend

https://encrypt-only-sensitive.api.im.dhis2.org
