### PR TITLE
Revert "ci: add nodeSelector and tolerations for dedicated IM envs node"

### DIFF
--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -21,14 +21,6 @@ deploy:
                       enabled: true
                       hostname: '{{ .UI_HOSTNAME }}'
                       certIssuer: cert-issuer-prod
-              setValues:
-                  tolerations:
-                      - key: im-dedicated
-                        operator: Equal
-                        value: true
-                        effect: NoSchedule
-                  nodeSelector:
-                      - im-dedicated: true
               valuesFiles:
                   - helm/data/values/{{ .CLASSIFICATION }}/values.yaml
 


### PR DESCRIPTION
Reverts dhis2-sre/im-web-client#657 to fix Build, Test and Deploy workflow until https://github.com/dhis2-sre/im-web-client/pull/663 is merged.