### PR TITLE
Custom dhis2 config

### DIFF
--- a/src/views/instances/new-dhis2/constants.ts
+++ b/src/views/instances/new-dhis2/constants.ts
@@ -15,7 +15,7 @@ export const PGADMIN_USERNAME = 'PGADMIN_USERNAME'
 export const PGADMIN_PASSWORD = 'PGADMIN_PASSWORD'
 export const PGADMIN_CONFIRM_PASSWORD = 'PGADMIN_CONFIRM_PASSWORD'
 export const OPTIONAL_FIELDS = new Set([JAVA_OPTS])
-export const PUBLIC = 'public'
+export const CUSTOM_DHIS2_CONFIG = 'CUSTOM_DHIS2_CONFIG'
 
 export const STACK_PRIMARY_PARAMETERS = new Map([
     ['dhis2-core', new Set(['IMAGE_TAG', 'IMAGE_REPOSITORY'])],

--- a/src/views/instances/new-dhis2/fields/parameter-field.tsx
+++ b/src/views/instances/new-dhis2/fields/parameter-field.tsx
@@ -1,5 +1,6 @@
 import type { FC } from 'react'
 import {
+    CUSTOM_DHIS2_CONFIG,
     DATABASE_ID,
     ENABLE_QUERY_LOGGING,
     FLYWAY_MIGRATE_OUT_OF_ORDER,
@@ -20,6 +21,7 @@ import { ImageRepositorySelect } from './image-repository-select.tsx'
 import { ImageTagSelect } from './image-tag-select.tsx'
 import { IntergrationParameterSelect } from './intergration-parameter-select.tsx'
 import { TextParameterInput } from './text-parameter-input.tsx'
+import { TextareaParameter } from './textarea-parameter.tsx'
 
 export type ParameterFieldProps = {
     displayName: string
@@ -52,6 +54,8 @@ export const ParameterField: FC<ParameterFieldProps> = ({ stackId, displayName, 
             return <TextParameterInput stackId={stackId} parameterName={parameterName} displayName={displayName} type="password" />
         case PGADMIN_CONFIRM_PASSWORD:
             return <ConfirmPasswordInput stackId={stackId} />
+        case CUSTOM_DHIS2_CONFIG:
+            return <TextareaParameter stackId={stackId} parameterName={parameterName} displayName={displayName} />
         default:
             return <TextParameterInput stackId={stackId} parameterName={parameterName} displayName={displayName} />
     }

--- a/src/views/instances/new-dhis2/fields/textarea-parameter.tsx
+++ b/src/views/instances/new-dhis2/fields/textarea-parameter.tsx
@@ -1,0 +1,9 @@
+import { TextAreaFieldFF } from '@dhis2/ui'
+import { FC } from 'react'
+import { Field } from 'react-final-form'
+import styles from './fields.module.css'
+import { ParameterFieldProps } from './parameter-field.tsx'
+
+export const TextareaParameter: FC<ParameterFieldProps> = ({ stackId, parameterName, displayName }) => {
+    return <Field className={styles.textarea} name={`${stackId}.${parameterName}`} label={displayName} component={TextAreaFieldFF} />
+}


### PR DESCRIPTION
The goal of this PR is to allow a snippet of custom DHIS2 configuration to be added to a given instance.

It works by simply appending an arbitrary piece of user supplied text to the dhis2.conf file.

After merging this PR a new field labeled "Custom DHIS2 config" will be shown under the "Advanced configuration" when deploying a DHIS2 core instance.