### PR TITLE
fix(e2e): default target group to whoami

### DIFF
--- a/e2e/utils/env.ts
+++ b/e2e/utils/env.ts
@@ -1,5 +1,5 @@
 export const username = process.env.USER_EMAIL
 export const password = process.env.USER_PASSWORD
 
-export const targetGroup = process.env.TARGET_GROUP || 'hcloud'
+export const targetGroup = process.env.TARGET_GROUP || 'whoami'
 export const dhis2CoreImageTag = process.env.DHIS2_CORE_IMAGE_TAG || '42'


### PR DESCRIPTION
The e2e tests default `TARGET_GROUP` to `hcloud`, which only exists on dev. Running the workflow against any feat backend (`*.api.im-feat.dhis2.org`) fails because the Group dropdown never contains an `hcloud` option.

`whoami` is the right default for every env this workflow can target.

All e2e specs are self-contained (each uploads/creates and tears down its own data), so they don't need to depend on `hcloud` for any pre-existing fixtures.