### PR TITLE
feat: some instance management ui tweaks

### DIFF
--- a/src/views/instances/list/filter-deployments.tsx
+++ b/src/views/instances/list/filter-deployments.tsx
@@ -28,19 +28,34 @@ const useDeployments = () => {
         [_setShowOnlyMyInstances]
     )
 
+    const [searchTerm, setSearchTerm] = useState('')
+
     const { currentUser } = useContext(AuthContext)
 
     const filteredData = useMemo(() => {
-        let filteredGroups = data?.map((group) => ({
-            ...group,
-            deployments: group.deployments.filter((deployment) => deployment.user.id === currentUser.id),
-        }))
-        if (filteredGroups) {
-            filteredGroups = filteredGroups.filter((group) => group.deployments.length > 0)
+        let groups = showOnlyMyInstances
+            ? data
+                  ?.map((group) => ({
+                      ...group,
+                      deployments: group.deployments.filter((deployment) => deployment.user.id === currentUser.id),
+                  }))
+                  ?.filter((group) => group.deployments.length > 0)
+            : data
+
+        if (searchTerm) {
+            const term = searchTerm.toLowerCase()
+            groups = groups
+                ?.map((group) => ({
+                    ...group,
+                    deployments: group.deployments.filter(
+                        (d) => d.name?.toLowerCase().includes(term) || d.description?.toLowerCase().includes(term) || d.user?.email?.toLowerCase().includes(term)
+                    ),
+                }))
+                ?.filter((group) => group.deployments.length > 0)
         }
 
-        return showOnlyMyInstances ? filteredGroups : data
-    }, [data, currentUser, showOnlyMyInstances])
+        return groups
+    }, [data, currentUser, showOnlyMyInstances, searchTerm])
 
     return {
         data: filteredData,
@@ -49,6 +64,8 @@ const useDeployments = () => {
         refetch,
         showOnlyMyInstances,
         setShowOnlyMyInstances,
+        searchTerm,
+        setSearchTerm,
     }
 }
 

--- a/src/views/instances/list/instances-list.module.css
+++ b/src/views/instances/list/instances-list.module.css
@@ -12,6 +12,13 @@
 .clickableRow {
     cursor: pointer;
 }
+.sortableHeader {
+    cursor: pointer;
+    user-select: none;
+}
+.searchInput {
+    min-width: 250px;
+}
 .groupName {
     font-size: 1.2rem;
     font-weight: bold;

--- a/src/views/instances/list/instances-list.tsx
+++ b/src/views/instances/list/instances-list.tsx
@@ -9,21 +9,76 @@ import {
     DataTableColumnHeader,
     DataTableRow,
     IconAdd24,
+    InputField,
     NoticeBox,
     Checkbox,
 } from '@dhis2/ui'
-import type { FC } from 'react'
+import { useState, useMemo, type FC } from 'react'
 import Moment from 'react-moment'
 import { useNavigate } from 'react-router-dom'
 import { Heading, MomentExpiresFromNow } from '../../../components/index.ts'
+import { Deployment } from '../../../types/index.ts'
 import { DeleteButton } from './delete-menu-button.tsx'
 import useDeployments from './filter-deployments.tsx'
 import InstanceTag from './instance-tag.tsx'
 import styles from './instances-list.module.css'
 import { OpenButton } from './open-button.tsx'
+
+type SortField = 'name' | 'description' | 'created' | 'updated' | 'owner' | 'expires'
+type SortDirection = 'asc' | 'desc'
+
+const compareByField = (a: Deployment, b: Deployment, field: SortField): number => {
+    switch (field) {
+        case 'name':
+            return (a.name ?? '').localeCompare(b.name ?? '')
+        case 'description':
+            return (a.description ?? '').localeCompare(b.description ?? '')
+        case 'created':
+            return (a.createdAt ?? '').localeCompare(b.createdAt ?? '')
+        case 'updated':
+            return (a.updatedAt ?? '').localeCompare(b.updatedAt ?? '')
+        case 'owner':
+            return (a.user?.email ?? '').localeCompare(b.user?.email ?? '')
+        case 'expires': {
+            const aExpires = new Date(a.createdAt).getTime() / 1000 + a.ttl || 0
+            const bExpires = new Date(b.createdAt).getTime() / 1000 + b.ttl || 0
+            return aExpires - bExpires
+        }
+        default:
+            return 0
+    }
+}
+
 export const InstancesList: FC = () => {
     const navigate = useNavigate()
-    const { data, error, loading, refetch, showOnlyMyInstances, setShowOnlyMyInstances } = useDeployments()
+    const { data, error, loading, refetch, showOnlyMyInstances, setShowOnlyMyInstances, searchTerm, setSearchTerm } = useDeployments()
+
+    const [sortField, setSortField] = useState<SortField | null>(null)
+    const [sortDirection, setSortDirection] = useState<SortDirection>('asc')
+
+    const handleSort = (field: SortField) => {
+        if (sortField === field) {
+            setSortDirection((prev) => (prev === 'asc' ? 'desc' : 'asc'))
+        } else {
+            setSortField(field)
+            setSortDirection('asc')
+        }
+    }
+
+    const sortedData = useMemo(() => {
+        if (!data || !sortField) {
+            return data
+        }
+        return data.map((group) => ({
+            ...group,
+            deployments: [...group.deployments].sort((a, b) => {
+                const cmp = compareByField(a, b, sortField)
+                return sortDirection === 'asc' ? cmp : -cmp
+            }),
+        }))
+    }, [data, sortField, sortDirection])
+
+    const sortIndicator = (field: SortField) => (sortField === field ? (sortDirection === 'asc' ? ' ↑' : ' ↓') : '')
 
     return (
         <div className={styles.wrapper}>
@@ -32,6 +87,7 @@ export const InstancesList: FC = () => {
                     New instance
                 </Button>
                 <Checkbox checked={showOnlyMyInstances} label="Show only my instances" onChange={() => setShowOnlyMyInstances(!showOnlyMyInstances)} />
+                <InputField placeholder="Search instances..." value={searchTerm} onChange={({ value }) => setSearchTerm(value)} dense className={styles.searchInput} />
             </Heading>
 
             {error && !data && (
@@ -40,11 +96,11 @@ export const InstancesList: FC = () => {
                 </NoticeBox>
             )}
 
-            {data?.length === 0 && <h3>No instances</h3>}
+            {sortedData?.length === 0 && <h3>No instances</h3>}
 
-            {data?.length > 0 && (
+            {sortedData?.length > 0 && (
                 <DataTable>
-                    {data?.map((group) => (
+                    {sortedData?.map((group) => (
                         <DataTableBody key={group.name}>
                             <DataTableRow>
                                 <DataTableCell staticStyle colSpan="9">
@@ -52,12 +108,37 @@ export const InstancesList: FC = () => {
                                 </DataTableCell>
                             </DataTableRow>
                             <DataTableRow>
-                                <DataTableColumnHeader>Name</DataTableColumnHeader>
+                                <DataTableColumnHeader>
+                                    <span className={styles.sortableHeader} onClick={() => handleSort('name')}>
+                                        Name{sortIndicator('name')}
+                                    </span>
+                                </DataTableColumnHeader>
+                                <DataTableColumnHeader>
+                                    <span className={styles.sortableHeader} onClick={() => handleSort('description')}>
+                                        Description{sortIndicator('description')}
+                                    </span>
+                                </DataTableColumnHeader>
                                 <DataTableColumnHeader>Status</DataTableColumnHeader>
-                                <DataTableColumnHeader>Created</DataTableColumnHeader>
-                                <DataTableColumnHeader>Updated</DataTableColumnHeader>
-                                <DataTableColumnHeader>Owner</DataTableColumnHeader>
-                                <DataTableColumnHeader>Expires</DataTableColumnHeader>
+                                <DataTableColumnHeader>
+                                    <span className={styles.sortableHeader} onClick={() => handleSort('created')}>
+                                        Created{sortIndicator('created')}
+                                    </span>
+                                </DataTableColumnHeader>
+                                <DataTableColumnHeader>
+                                    <span className={styles.sortableHeader} onClick={() => handleSort('updated')}>
+                                        Updated{sortIndicator('updated')}
+                                    </span>
+                                </DataTableColumnHeader>
+                                <DataTableColumnHeader>
+                                    <span className={styles.sortableHeader} onClick={() => handleSort('owner')}>
+                                        Owner{sortIndicator('owner')}
+                                    </span>
+                                </DataTableColumnHeader>
+                                <DataTableColumnHeader>
+                                    <span className={styles.sortableHeader} onClick={() => handleSort('expires')}>
+                                        Expires{sortIndicator('expires')}
+                                    </span>
+                                </DataTableColumnHeader>
                                 <DataTableColumnHeader></DataTableColumnHeader>
                             </DataTableRow>
 
@@ -73,6 +154,7 @@ export const InstancesList: FC = () => {
                                     }}
                                 >
                                     <DataTableCell>{deployment.name}</DataTableCell>
+                                    <DataTableCell>{deployment.description}</DataTableCell>
                                     <DataTableCell>
                                         {deployment.instances?.map(({ stackName, id }) => (
                                             <InstanceTag key={stackName} instanceId={id} stackName={stackName} />

--- a/src/views/instances/list/instances-list.tsx
+++ b/src/views/instances/list/instances-list.tsx
@@ -147,7 +147,7 @@ export const InstancesList: FC = () => {
                                     className={styles.clickableRow}
                                     key={deployment.id}
                                     onClick={(e) => {
-                                        if ((e.target as HTMLElement).closest('[data-test="dhis2-uicore-modal"]')) {
+                                        if (!e.currentTarget.contains(e.target as Node)) {
                                             return
                                         }
                                         navigate(`/instances/${deployment.id}/details`, { state: deployment })


### PR DESCRIPTION
*I've had this sitting on a branch since the recent DB management updates - so just pushing it rather than losing it*

Basically it adds sorting to the instance tables, and a search bar at the top - bringing the functionality in line with the databases panel. The search works across name, description and owner.