### PR TITLE
fix(notifications): use IconSubscribe24 from @dhis2/ui instead of inline SVG

### DIFF
--- a/src/components/notifications/notification-bell.tsx
+++ b/src/components/notifications/notification-bell.tsx
@@ -1,14 +1,9 @@
 import { useAlert } from '@dhis2/app-service-alerts'
+import { IconSubscribe24 } from '@dhis2/ui'
 import { type FC, useCallback, useEffect, useState } from 'react'
 import { useNotifications } from '../../hooks/use-notifications.ts'
 import styles from './notification-bell.module.css'
 import { NotificationPanel } from './notification-panel.tsx'
-
-const BellIcon: FC = () => (
-    <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-        <path d="M12 22c1.1 0 2-.9 2-2h-4c0 1.1.9 2 2 2zm6-6v-5c0-3.07-1.63-5.64-4.5-6.32V4c0-.83-.67-1.5-1.5-1.5s-1.5.67-1.5 1.5v.68C7.64 5.36 6 7.92 6 11v5l-2 2v1h16v-1l-2-2z" />
-    </svg>
-)
 
 export const NotificationBell: FC = () => {
     const [open, setOpen] = useState(false)
@@ -48,7 +43,7 @@ export const NotificationBell: FC = () => {
         <div className={styles.wrapper}>
             {open && <div className={styles.overlay} onClick={close} />}
             <button className={`${styles.button} ${open ? styles.active : ''}`} onClick={toggle} aria-label="Notifications">
-                <BellIcon />
+                <IconSubscribe24 />
                 {unreadCount > 0 && <span className={styles.badge}>{unreadCount > 99 ? '99+' : unreadCount}</span>}
             </button>
             {open && <NotificationPanel notifications={notifications} unreadCount={unreadCount} onMarkRead={handleMarkRead} onMarkAllRead={handleMarkAllRead} />}


### PR DESCRIPTION
Addresses @radnov's review comment on #771: replace the inline bell SVG in the notification button with `IconSubscribe24` from `@dhis2/ui`.

## Test plan

- [ ] Bell icon renders in the sidebar footer
- [ ] Hover/active styling still works (icon inherits `currentColor`)
- [ ] Unread badge still overlays the icon correctly