### PR TITLE
feat: add lifetime extension to instance update form

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -15,3 +15,10 @@ a {
 a:hover {
     color: var(--colors-blue800);
 }
+
+/* @dhis2/ui CalendarInput's internal .calendar-wrapper element renders with
+   `background-color: none`, so underlying page content bleeds through.
+   Global override (not a CSS module) targeting the upstream class name. */
+.calendar-wrapper {
+    background-color: var(--colors-white);
+}

--- a/src/views/instances/new-dhis2/fields/custom-date-calendar.tsx
+++ b/src/views/instances/new-dhis2/fields/custom-date-calendar.tsx
@@ -1,0 +1,23 @@
+import { CalendarInput } from '@dhis2/ui'
+import { FC } from 'react'
+import styles from './fields.module.css'
+
+type Props = {
+    date: string
+    minDate?: string
+    onDateSelect: (calendarDateString: string) => void
+}
+
+// Use 'gregory' not 'iso8601': @js-temporal/polyfill returns "" for toLocaleString({calendar:'iso8601', month:'long'}),
+// so @dhis2/ui's <select value={currMonth.label}> falls back to its first option ("January") regardless of the actual visible month.
+export const CustomDateCalendar: FC<Props> = ({ date, minDate, onDateSelect }) => (
+    <div className={styles.calendarContainer}>
+        <CalendarInput
+            calendar="gregory"
+            date={date}
+            // @ts-expect-error minDate is supported at runtime; @dhis2/ui type defs omit it
+            minDate={minDate}
+            onDateSelect={(d: { calendarDateString: string }) => onDateSelect(d.calendarDateString)}
+        />
+    </div>
+)

--- a/src/views/instances/new-dhis2/fields/extend-ttl-select.tsx
+++ b/src/views/instances/new-dhis2/fields/extend-ttl-select.tsx
@@ -1,0 +1,69 @@
+import { SingleSelectField, SingleSelectOption } from '@dhis2/ui'
+import moment from 'moment'
+import { useState } from 'react'
+import { useField } from 'react-final-form'
+import { Deployment } from '../../../../types/index.ts'
+import { CustomDateCalendar } from './custom-date-calendar.tsx'
+import styles from './fields.module.css'
+import { CUSTOM_LABEL, CUSTOM_VALUE, TTL_PRESETS } from './ttl-presets.ts'
+
+export const ExtendTtlSelect = ({ deployment }: { deployment: Deployment }) => {
+    const originalTtl = deployment.ttl ?? 0
+    const createdAtMs = new Date(deployment.createdAt!).getTime()
+    const currentEndMs = createdAtMs + originalTtl * 1000
+
+    const { input, meta } = useField<number>('ttl', {
+        subscription: { value: true, error: true },
+        validate: (v) => (typeof v === 'number' && v < originalTtl ? `Pick a date later than the current expiry (${moment(currentEndMs).format('YYYY-MM-DD HH:mm')}).` : undefined),
+    })
+
+    const [customMode, setCustomMode] = useState(false)
+    const [nowMs] = useState(() => Date.now())
+
+    const ageSeconds = Math.floor((nowMs - createdAtMs) / 1000)
+    const remainingSeconds = Math.floor((currentEndMs - nowMs) / 1000)
+    const value = Number(input.value) || 0
+    const extensionSeconds = value - ageSeconds
+    const matchedPreset = TTL_PRESETS.find((p) => p.seconds === extensionSeconds)
+    const selected = customMode ? CUSTOM_VALUE : matchedPreset ? String(matchedPreset.seconds) : ''
+    const calendarDate = customMode && value > 0 ? new Date(createdAtMs + value * 1000).toISOString().split('T')[0] : ''
+    const remainingLabel = remainingSeconds > 0 ? `${moment.duration(remainingSeconds, 'seconds').humanize()} remaining` : 'expired'
+
+    const handleSelect = (next: string) => {
+        if (next === CUSTOM_VALUE) {
+            setCustomMode(true)
+        } else {
+            setCustomMode(false)
+            input.onChange(ageSeconds + parseInt(next, 10))
+        }
+    }
+
+    const handleDate = (s: string) => input.onChange(Math.floor((new Date(`${s}T23:59:59`).getTime() - createdAtMs) / 1000))
+
+    return (
+        <div className={styles.extendTtl}>
+            <SingleSelectField
+                className={styles.field}
+                label={`Lifetime (${remainingLabel})`}
+                selected={selected}
+                placeholder="Pick a new lifetime..."
+                onChange={({ selected: next }: { selected: string }) => handleSelect(next)}
+                helpText="How long this instance will run from now until automatic shutdown."
+            >
+                {TTL_PRESETS.map((p) => (
+                    <SingleSelectOption key={p.seconds} value={String(p.seconds)} label={p.label} disabled={p.seconds <= remainingSeconds} />
+                ))}
+                <SingleSelectOption value={CUSTOM_VALUE} label={CUSTOM_LABEL} />
+            </SingleSelectField>
+            {customMode && (
+                <>
+                    <CustomDateCalendar date={calendarDate} minDate={new Date(currentEndMs).toISOString().split('T')[0]} onDateSelect={handleDate} />
+                    {meta.error && <div className={styles.dateError}>{meta.error}</div>}
+                </>
+            )}
+            {value > 0 && value !== originalTtl && !meta.error && (
+                <div className={styles.willExpire}>Will expire on {moment(createdAtMs + value * 1000).format('YYYY-MM-DD HH:mm')}</div>
+            )}
+        </div>
+    )
+}

--- a/src/views/instances/new-dhis2/fields/extend-ttl-select.tsx
+++ b/src/views/instances/new-dhis2/fields/extend-ttl-select.tsx
@@ -5,28 +5,28 @@ import { useField } from 'react-final-form'
 import { Deployment } from '../../../../types/index.ts'
 import { CustomDateCalendar } from './custom-date-calendar.tsx'
 import styles from './fields.module.css'
-import { CUSTOM_LABEL, CUSTOM_VALUE, TTL_PRESETS } from './ttl-presets.ts'
+import { CUSTOM_LABEL, CUSTOM_VALUE, DATE_FORMAT, DATETIME_FORMAT, TTL_PRESETS } from './ttl-presets.ts'
 
 export const ExtendTtlSelect = ({ deployment }: { deployment: Deployment }) => {
     const originalTtl = deployment.ttl ?? 0
     const createdAtMs = new Date(deployment.createdAt!).getTime()
     const currentEndMs = createdAtMs + originalTtl * 1000
 
-    const { input, meta } = useField<number>('ttl', {
-        subscription: { value: true, error: true },
-        validate: (v) => (typeof v === 'number' && v < originalTtl ? `Pick a date later than the current expiry (${moment(currentEndMs).format('YYYY-MM-DD HH:mm')}).` : undefined),
-    })
-
     const [customMode, setCustomMode] = useState(false)
     const [nowMs] = useState(() => Date.now())
 
     const ageSeconds = Math.floor((nowMs - createdAtMs) / 1000)
     const remainingSeconds = Math.floor((currentEndMs - nowMs) / 1000)
+
+    const { input, meta } = useField<number>('ttl', {
+        subscription: { value: true, error: true },
+        validate: (v) => (typeof v === 'number' && v > 0 && v <= ageSeconds ? `Pick a date in the future.` : undefined),
+    })
     const value = Number(input.value) || 0
     const extensionSeconds = value - ageSeconds
     const matchedPreset = TTL_PRESETS.find((p) => p.seconds === extensionSeconds)
     const selected = customMode ? CUSTOM_VALUE : matchedPreset ? String(matchedPreset.seconds) : ''
-    const calendarDate = customMode && value > 0 ? new Date(createdAtMs + value * 1000).toISOString().split('T')[0] : ''
+    const calendarDate = customMode && value > 0 ? moment(createdAtMs + value * 1000).format(DATE_FORMAT) : ''
     const remainingLabel = remainingSeconds > 0 ? `${moment.duration(remainingSeconds, 'seconds').humanize()} remaining` : 'expired'
 
     const handleSelect = (next: string) => {
@@ -51,18 +51,18 @@ export const ExtendTtlSelect = ({ deployment }: { deployment: Deployment }) => {
                 helpText="How long this instance will run from now until automatic shutdown."
             >
                 {TTL_PRESETS.map((p) => (
-                    <SingleSelectOption key={p.seconds} value={String(p.seconds)} label={p.label} disabled={p.seconds <= remainingSeconds} />
+                    <SingleSelectOption key={p.seconds} value={String(p.seconds)} label={p.label} />
                 ))}
                 <SingleSelectOption value={CUSTOM_VALUE} label={CUSTOM_LABEL} />
             </SingleSelectField>
             {customMode && (
                 <>
-                    <CustomDateCalendar date={calendarDate} minDate={new Date(currentEndMs).toISOString().split('T')[0]} onDateSelect={handleDate} />
+                    <CustomDateCalendar date={calendarDate} minDate={moment(nowMs).format(DATE_FORMAT)} onDateSelect={handleDate} />
                     {meta.error && <div className={styles.dateError}>{meta.error}</div>}
                 </>
             )}
             {value > 0 && value !== originalTtl && !meta.error && (
-                <div className={styles.willExpire}>Will expire on {moment(createdAtMs + value * 1000).format('YYYY-MM-DD HH:mm')}</div>
+                <div className={styles.willExpire}>Will expire on {moment(createdAtMs + value * 1000).format(DATETIME_FORMAT)}</div>
             )}
         </div>
     )

--- a/src/views/instances/new-dhis2/fields/fields.module.css
+++ b/src/views/instances/new-dhis2/fields/fields.module.css
@@ -7,7 +7,7 @@
 .parameterCheckbox {
     padding-top: 18px;
 }
-.calenderContainer {
+.calendarContainer {
     margin-top: 15px;
 }
 
@@ -35,4 +35,22 @@
 .customOption:active .secondaryText,
 .customOption.active .secondaryText {
     color: var(--colors-grey400);
+}
+
+.extendTtl {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    max-width: 480px;
+}
+
+.willExpire {
+    font-size: 12px;
+    color: var(--colors-grey700);
+}
+
+.dateError {
+    font-size: 12px;
+    color: var(--colors-red700);
+    margin-top: 4px;
 }

--- a/src/views/instances/new-dhis2/fields/ttl-presets.ts
+++ b/src/views/instances/new-dhis2/fields/ttl-presets.ts
@@ -4,6 +4,9 @@ export const DAY_IN_SECONDS = HOUR_IN_SECONDS * 24
 export const CUSTOM_VALUE = 'custom'
 export const CUSTOM_LABEL = 'Custom...'
 
+export const DATE_FORMAT = 'YYYY-MM-DD'
+export const DATETIME_FORMAT = `${DATE_FORMAT} HH:mm`
+
 export type TtlPreset = { label: string; seconds: number }
 
 export const TTL_PRESETS: TtlPreset[] = [

--- a/src/views/instances/new-dhis2/fields/ttl-presets.ts
+++ b/src/views/instances/new-dhis2/fields/ttl-presets.ts
@@ -1,0 +1,19 @@
+export const HOUR_IN_SECONDS = 60 * 60
+export const DAY_IN_SECONDS = HOUR_IN_SECONDS * 24
+
+export const CUSTOM_VALUE = 'custom'
+export const CUSTOM_LABEL = 'Custom...'
+
+export type TtlPreset = { label: string; seconds: number }
+
+export const TTL_PRESETS: TtlPreset[] = [
+    { label: '1 hour', seconds: HOUR_IN_SECONDS },
+    { label: '6 hours', seconds: 6 * HOUR_IN_SECONDS },
+    { label: '12 hours', seconds: 12 * HOUR_IN_SECONDS },
+    { label: '1 day', seconds: DAY_IN_SECONDS },
+    { label: '2 days', seconds: 2 * DAY_IN_SECONDS },
+    { label: '5 days', seconds: 5 * DAY_IN_SECONDS },
+    { label: '1 week', seconds: 7 * DAY_IN_SECONDS },
+    { label: '2 weeks', seconds: 14 * DAY_IN_SECONDS },
+    { label: '1 month', seconds: 28 * DAY_IN_SECONDS },
+]

--- a/src/views/instances/new-dhis2/fields/ttl-select.tsx
+++ b/src/views/instances/new-dhis2/fields/ttl-select.tsx
@@ -1,47 +1,32 @@
-import { SingleSelectField, SingleSelectOption, CalendarInput } from '@dhis2/ui'
-import React, { useState } from 'react'
+import { SingleSelectField, SingleSelectOption } from '@dhis2/ui'
+import { useState } from 'react'
 import { useField } from 'react-final-form'
+import { CustomDateCalendar } from './custom-date-calendar.tsx'
 import styles from './fields.module.css'
-
-const defaultTTL = 60 * 60 * 24
-const options = [
-    { label: '1 hour', value: (60 * 60).toString() },
-    { label: '6 hours', value: (60 * 60 * 6).toString() },
-    { label: '12 hours', value: (60 * 60 * 12).toString() },
-    { label: '1 day', value: defaultTTL.toString() },
-    { label: '2 days', value: (60 * 60 * 24 * 2).toString() },
-    { label: '5 days', value: (60 * 60 * 24 * 5).toString() },
-    { label: '1 week', value: (60 * 60 * 24 * 7).toString() },
-    { label: '2 weeks', value: (60 * 60 * 24 * 7 * 2).toString() },
-    { label: '1 month', value: (60 * 60 * 24 * 7 * 4).toString() },
-    { label: 'Custom', value: '-1' },
-]
+import { CUSTOM_LABEL, CUSTOM_VALUE, TTL_PRESETS } from './ttl-presets.ts'
 
 export const TtlSelect = () => {
-    const { input: ttlInput } = useField('ttl', { subscription: { value: true } })
-    const [selectedValue, setSelectedValue] = useState(ttlInput.value.toString())
-    const [showCalendar, setShowCalendar] = useState(false)
+    const { input } = useField<number>('ttl', { subscription: { value: true } })
+    const [customMode, setCustomMode] = useState(false)
     const [calendarDate, setCalendarDate] = useState('')
 
-    const handleSelectChange = (value: string) => {
-        setSelectedValue(value)
-        if (value === '-1') {
-            setShowCalendar(true)
+    const value = Number(input.value) || 0
+    const matchedPreset = TTL_PRESETS.find((p) => p.seconds === value)
+    const selected = customMode ? CUSTOM_VALUE : matchedPreset ? String(matchedPreset.seconds) : ''
+
+    const handleSelectChange = (next: string) => {
+        if (next === CUSTOM_VALUE) {
+            setCustomMode(true)
         } else {
-            ttlInput.onChange(parseInt(value, 10))
-            setShowCalendar(false)
+            setCustomMode(false)
+            setCalendarDate('')
+            input.onChange(parseInt(next, 10))
         }
     }
 
-    const handleCustomDateChange = (date) => {
-        const currentDate = new Date()
-        const targetDate = new Date(date.calendarDateString + 'T00:00:00Z')
-        const differenceInMs = targetDate.getTime() - currentDate.getTime()
-
-        const differenceInSeconds = Math.floor(differenceInMs / 1000)
-        ttlInput.onChange(differenceInSeconds)
-        setSelectedValue('-1')
-        setCalendarDate(targetDate.toISOString().split('T')[0])
+    const handleDate = (s: string) => {
+        input.onChange(Math.floor((new Date(`${s}T00:00:00Z`).getTime() - Date.now()) / 1000))
+        setCalendarDate(s)
     }
 
     return (
@@ -49,19 +34,16 @@ export const TtlSelect = () => {
             <SingleSelectField
                 className={styles.field}
                 label="Lifetime"
-                selected={selectedValue}
-                onChange={({ selected }: { selected: string }) => handleSelectChange(selected)}
+                selected={selected}
+                onChange={({ selected: next }: { selected: string }) => handleSelectChange(next)}
                 helpText="How long this instance will run for until automatic shutdown."
             >
-                {options.map((option) => (
-                    <SingleSelectOption key={option.value} label={option.label} value={option.value} />
+                {TTL_PRESETS.map((p) => (
+                    <SingleSelectOption key={p.seconds} label={p.label} value={String(p.seconds)} />
                 ))}
+                <SingleSelectOption label={CUSTOM_LABEL} value={CUSTOM_VALUE} />
             </SingleSelectField>
-            {showCalendar && (
-                <div className={styles.calenderContainer}>
-                    <CalendarInput onDateSelect={handleCustomDateChange} calendar="iso8601" date={calendarDate} />
-                </div>
-            )}
+            {customMode && <CustomDateCalendar date={calendarDate} onDateSelect={handleDate} />}
         </div>
     )
 }

--- a/src/views/instances/new-dhis2/new-dhis2-instance-form.tsx
+++ b/src/views/instances/new-dhis2/new-dhis2-instance-form.tsx
@@ -5,6 +5,7 @@ import { useFormState } from 'react-final-form'
 import { Deployment } from '../../../types/index.ts'
 import { CompanionFieldset } from './companion-fieldset.tsx'
 import { DescriptionTextarea } from './fields/description-textarea.tsx'
+import { ExtendTtlSelect } from './fields/extend-ttl-select.tsx'
 import { GroupSelect } from './fields/group-select.tsx'
 import { NameInput } from './fields/name-input.tsx'
 import { PublicCheckbox } from './fields/public-checkbox.tsx'
@@ -62,7 +63,7 @@ export const NewDhis2InstanceForm = ({ handleCancel, handleSubmit, mode = 'creat
                 {!isUpdate && <NameInput />}
                 <DescriptionTextarea />
                 <PublicCheckbox />
-                <TtlSelect />
+                {isUpdate && deployment ? <ExtendTtlSelect deployment={deployment} /> : <TtlSelect />}
                 {!isUpdate && <GroupSelect />}
             </fieldset>
             <hr className={styles.hr} />


### PR DESCRIPTION
Adds ExtendTtlSelect, used in the update flow alongside the existing TtlSelect.

Same preset list as create mode, plus Custom that opens a calendar. The new lifetime can be longer or shorter than the current one - any future expiry is allowed. Field-level validator on ttl rejects values whose target lies in the past, so an invalid pick blocks form submit. Header label shows current remaining time via moment.duration(seconds).humanize(); "Will expire on ..." preview shown when changed and valid. Date strings use a shared YYYY-MM-DD / YYYY-MM-DD HH:mm format to avoid locale-dependent (US) output.

Two CalendarInput caveats worked around:
- calendar="gregory" not "iso8601": @js-temporal/polyfill returns "" from toLocaleString({calendar:'iso8601', month:'long'}), so @dhis2/ui's month <select value=""> falls back to its first option ("January") in the header. The grid renders the correct month but the dropdown lies. gregory has the same behaviour for our use case without the broken label.
- Global .calendar-wrapper override in index.css: @dhis2/ui's internal .calendar-wrapper renders with background-color: none, so underlying page content bleeds through the popper.