### PR TITLE
fix: pass null to useRef for React 19 compatibility

### DIFF
--- a/src/views/instances/details/actions-dropdown-menu.tsx
+++ b/src/views/instances/details/actions-dropdown-menu.tsx
@@ -26,7 +26,7 @@ export type AsyncActionProps = {
 }
 
 export const ActionsDropdownMenu = ({ deploymentId, instanceId, stackName, refetch }: ActionsDropdownMenuProps) => {
-    const anchor = useRef()
+    const anchor = useRef<HTMLSpanElement>(null)
     const [open, setOpen] = useState(false)
     const [loading, setLoading] = useState(false)
     const onStart = useCallback(() => {


### PR DESCRIPTION
Single bare \`useRef()\` call in \`actions-dropdown-menu.tsx\` was fine under React 18 but breaks under React 19, which made the initial value argument required. Aligns with the typed pattern already used in \`database-row-action.tsx\`.

Unblocks dependabot PR #789 (react 18→19 bump).

## Test plan
- [x] \`yarn build\` passes
- [x] \`yarn lint\` passes
- [x] \`yarn test\` passes
- [ ] CI green