### PR TITLE
fix: render boolean parameter checkboxes via useField for react-final-form 7

### DIFF
--- a/src/views/instances/new-dhis2/fields/boolean-parameter-checkbox.tsx
+++ b/src/views/instances/new-dhis2/fields/boolean-parameter-checkbox.tsx
@@ -1,22 +1,25 @@
-import { CheckboxFieldFF } from '@dhis2/ui'
+import { CheckboxField } from '@dhis2/ui'
 import { FC } from 'react'
-import { Field } from 'react-final-form'
+import { useField } from 'react-final-form'
 import styles from './fields.module.css'
 import { ParameterFieldProps } from './parameter-field.tsx'
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const parseBool = (bool: any): string => (typeof bool === 'boolean' && bool ? 'true' : 'false')
-export const formatBool = (str: string): boolean => str === 'true'
-
-export const BooleanParameterCheckbox: FC<ParameterFieldProps> = ({ displayName, parameterName, stackId }) => (
-    <Field
-        type="checkbox"
-        format={formatBool}
-        parse={parseBool}
-        required
-        name={`${stackId}.${parameterName}`}
-        label={displayName}
-        component={CheckboxFieldFF}
-        className={styles.parameterCheckbox}
-    />
-)
+// Form state holds 'true'/'false' strings to match the API shape. We render the
+// checkbox via useField + CheckboxField directly because react-final-form 7's
+// `<Field type="checkbox">` computes `checked` as `!!parse(state.value)`, which
+// gives `!!'false' === true` for a string-valued state — leaving every checkbox
+// stuck in the checked position. See https://github.com/final-form/react-final-form/pull/1074
+export const BooleanParameterCheckbox: FC<ParameterFieldProps> = ({ displayName, parameterName, stackId }) => {
+    const name = `${stackId}.${parameterName}`
+    const { input } = useField(name, { subscription: { value: true } })
+    return (
+        <CheckboxField
+            name={name}
+            label={displayName}
+            required
+            checked={input.value === 'true'}
+            onChange={({ checked }) => input.onChange(checked ? 'true' : 'false')}
+            className={styles.parameterCheckbox}
+        />
+    )
+}


### PR DESCRIPTION
## Summary

After upgrading to react-final-form 7 (pulled in by #789, the React 19 bump), every checkbox under DHIS2 Core's *Advanced configuration* renders as checked and cannot be unchecked.

## Root cause

react-final-form 7.0.1 deliberately changed the checkbox `checked` getter from `!!format(state.value)` to `!!parse(state.value)` ([final-form/react-final-form#1074](https://github.com/final-form/react-final-form/pull/1074), fixes [#974](https://github.com/final-form/react-final-form/issues/974), shipped in [v7.0.1](https://github.com/final-form/react-final-form/releases/tag/v7.0.1)). The library now expects `!!parse(stored_value)` to round-trip back to the boolean checked state.

`BooleanParameterCheckbox` stored 'true'/'false' strings and used:

```ts
parseBool = (bool) => (typeof bool === 'boolean' && bool ? 'true' : 'false')
formatBool = (str) => str === 'true'
```

`parseBool` only returns `'true'` when its input is the boolean `true`. For any string input it returns `'false'`, and `!!'false'` is `true`. So:

- Field state `'true'`: `!!parseBool('true')` → `!!'false'` → `true` (checked, correct)
- Field state `'false'`: `!!parseBool('false')` → `!!'false'` → `true` (checked, **wrong**)
- Click to uncheck: state moves to `'false'`, next render still computes `true`. Stuck.

This is not a bug from upstream's perspective — they consider the `parse`-based round-trip the canonical contract. The v6 → v7 behavior change just exposed that our `parse`/`format` pair was never a true inverse.

## Fix

Render the checkbox via `useField` + `CheckboxField` directly so `checked` is computed from the raw form value instead of going through rff's `parse`-based `getInputChecked`. Keeps the existing 'true'/'false' string shape in form state, so no ripple changes are needed in initialization, submit serialization, or the `DEPLOY_CHAP === 'true'` cross-field check.

## Test plan

- [ ] Open `/instances/new` on a deploy of this branch
- [ ] Expand *DHIS2 Core → Advanced configuration*
- [ ] Verify each checkbox renders with its API default (some checked, some unchecked)
- [ ] Toggle each checkbox and confirm it actually toggles
- [ ] Toggle `Deploy CHAP` and confirm the CHAP companion stack fieldsets appear/disappear
- [ ] Create an instance, then edit it; confirm the boolean parameter values from the existing deployment round-trip correctly in the edit form

## References

- [final-form/react-final-form v7.0.1 release notes](https://github.com/final-form/react-final-form/releases/tag/v7.0.1)
- [Issue #974: Use parse instead of format when calculating checked](https://github.com/final-form/react-final-form/issues/974)
- [PR #1074: Fix #974: Use parse instead of format in checkbox/radio checked logic](https://github.com/final-form/react-final-form/pull/1074)