### PR TITLE
fix: show API error message when account is not validated on sign-in

### DIFF
--- a/src/components/auth-provider.tsx
+++ b/src/components/auth-provider.tsx
@@ -70,12 +70,12 @@ export const AuthProvider: FC = () => {
                 setCurrentUser(userResponse.data)
             } catch (error) {
                 console.error(error)
-                const errorMessage =
-                    error instanceof AxiosError
-                        ? error.response?.data || error.message
-                        : error instanceof Error
-                          ? error.message
-                          : 'Unknown error'
+                let errorMessage = 'Unknown error'
+                if (error instanceof AxiosError) {
+                    errorMessage = error.response?.data || error.message
+                } else if (error instanceof Error) {
+                    errorMessage = error.message
+                }
                 setAuthenticationErrorMessage(errorMessage)
                 setCurrentUser(null)
             } finally {

--- a/src/components/auth-provider.tsx
+++ b/src/components/auth-provider.tsx
@@ -70,7 +70,12 @@ export const AuthProvider: FC = () => {
                 setCurrentUser(userResponse.data)
             } catch (error) {
                 console.error(error)
-                const errorMessage = error instanceof AxiosError || error instanceof Error ? error.message : 'Unknown error'
+                const errorMessage =
+                    error instanceof AxiosError
+                        ? error.response?.data || error.message
+                        : error instanceof Error
+                          ? error.message
+                          : 'Unknown error'
                 setAuthenticationErrorMessage(errorMessage)
                 setCurrentUser(null)
             } finally {


### PR DESCRIPTION
When a user whose account hasn't been validated attempts to sign in, the backend returns a 403 with the message "account not validated" in the response body. Previously, the login error handler used `error.message` which only gives the generic Axios message ("Request failed with status code 403") rather than the actual response body. This change extracts `error.response?.data` from `AxiosError` so the user sees the meaningful message from the API.

Closes https://dhis2.atlassian.net/browse/DEVOPS-548