### PR TITLE
feat: add cluster details page with edit functionality

### DIFF
--- a/src/app/app.tsx
+++ b/src/app/app.tsx
@@ -8,6 +8,7 @@ import '@fontsource/roboto/700.css'
 import { ReactElement } from 'react'
 import { createBrowserRouter, createRoutesFromElements, Route, RouterProvider } from 'react-router-dom'
 import { Alerts, AuthProvider, ErrorView, Layout, PublicLayout, StacksProvider } from '../components/index.ts'
+import { ClusterDetails } from '../views/clusters/cluster-details.tsx'
 import { ClustersList } from '../views/clusters/clusters-list.tsx'
 import { DatabaseDetails } from '../views/databases/database-details.tsx'
 import {
@@ -59,6 +60,7 @@ if (location.hostname === 'play.dhis2.org') {
                         <Route path="/databases" element={<DatabasesList />} />
                         <Route path="/databases/:id" element={<DatabaseDetails />} />
                         <Route path="/clusters" element={<ClustersList />} />
+                        <Route path="/clusters/:id" element={<ClusterDetails />} />
                         <Route path="/instances/new" element={<NewDhis2Instance />} />
                         <Route path="/instances/:id/edit" element={<EditDhis2Instance />} />
                         <Route path="/instances/:id/details" element={<DeploymentDetails />} />

--- a/src/views/clusters/cluster-details.tsx
+++ b/src/views/clusters/cluster-details.tsx
@@ -1,4 +1,15 @@
-import { Button, Center, CircularLoader, DataTable, DataTableBody as TableBody, DataTableCell, DataTableColumnHeader, DataTableHead as TableHead, DataTableRow, NoticeBox } from '@dhis2/ui'
+import {
+    Button,
+    Center,
+    CircularLoader,
+    DataTable,
+    DataTableBody as TableBody,
+    DataTableCell,
+    DataTableColumnHeader,
+    DataTableHead as TableHead,
+    DataTableRow,
+    NoticeBox,
+} from '@dhis2/ui'
 import type { FC } from 'react'
 import { useState } from 'react'
 import Moment from 'react-moment'

--- a/src/views/clusters/cluster-details.tsx
+++ b/src/views/clusters/cluster-details.tsx
@@ -1,0 +1,85 @@
+import { Button, Center, CircularLoader, DataTable, DataTableBody as TableBody, DataTableCell, DataTableColumnHeader, DataTableHead as TableHead, DataTableRow, NoticeBox } from '@dhis2/ui'
+import type { FC } from 'react'
+import { useState } from 'react'
+import Moment from 'react-moment'
+import { Link, useParams } from 'react-router-dom'
+import { Heading } from '../../components/index.ts'
+import { useAuthAxios } from '../../hooks/index.ts'
+import { Cluster } from '../../types/index.ts'
+import { EditClusterModal } from './edit-cluster-modal.tsx'
+
+export const ClusterDetails: FC = () => {
+    const { id } = useParams<{ id: string }>()
+    const [showEditModal, setShowEditModal] = useState(false)
+
+    const [{ data: cluster, loading, error }, refetch] = useAuthAxios<Cluster>(`/clusters/${id}`, { useCache: false })
+
+    if (loading) {
+        return (
+            <Center>
+                <CircularLoader />
+            </Center>
+        )
+    }
+
+    if (error) {
+        return (
+            <NoticeBox error title="Could not fetch cluster details">
+                {error.message}
+            </NoticeBox>
+        )
+    }
+
+    return (
+        <div>
+            <Heading title={cluster?.name ?? ''}>
+                <Button onClick={() => setShowEditModal(true)}>Edit</Button>
+            </Heading>
+
+            <DataTable>
+                <TableHead>
+                    <DataTableRow>
+                        <DataTableColumnHeader>Field</DataTableColumnHeader>
+                        <DataTableColumnHeader>Value</DataTableColumnHeader>
+                    </DataTableRow>
+                </TableHead>
+                <TableBody>
+                    <DataTableRow>
+                        <DataTableCell>Description</DataTableCell>
+                        <DataTableCell>{cluster?.description}</DataTableCell>
+                    </DataTableRow>
+                    <DataTableRow>
+                        <DataTableCell>Groups</DataTableCell>
+                        <DataTableCell>
+                            {cluster?.groups?.map((group, i) => (
+                                <span key={group.name}>
+                                    {i > 0 && ', '}
+                                    <Link to={`/groups/${group.name}`}>{group.name}</Link>
+                                </span>
+                            ))}
+                        </DataTableCell>
+                    </DataTableRow>
+                    <DataTableRow>
+                        <DataTableCell>Created</DataTableCell>
+                        <DataTableCell>{cluster?.createdAt && <Moment date={cluster.createdAt} fromNow />}</DataTableCell>
+                    </DataTableRow>
+                    <DataTableRow>
+                        <DataTableCell>Updated</DataTableCell>
+                        <DataTableCell>{cluster?.updatedAt && <Moment date={cluster.updatedAt} fromNow />}</DataTableCell>
+                    </DataTableRow>
+                </TableBody>
+            </DataTable>
+
+            {showEditModal && cluster && (
+                <EditClusterModal
+                    cluster={cluster}
+                    onComplete={() => {
+                        setShowEditModal(false)
+                        void refetch()
+                    }}
+                    onCancel={() => setShowEditModal(false)}
+                />
+            )}
+        </div>
+    )
+}

--- a/src/views/clusters/clusters-list.tsx
+++ b/src/views/clusters/clusters-list.tsx
@@ -30,7 +30,9 @@ export const ClustersList: FC = () => {
                     {data?.map((cluster: Cluster) => {
                         return (
                             <DataTableRow key={cluster.id}>
-                                <DataTableCell><Link to={`/clusters/${cluster.id}`}>{cluster.name}</Link></DataTableCell>
+                                <DataTableCell>
+                                    <Link to={`/clusters/${cluster.id}`}>{cluster.name}</Link>
+                                </DataTableCell>
                                 <DataTableCell>{cluster.description}</DataTableCell>
                                 <DataTableCell>{cluster.groups?.map((group) => group.name).join(', ')}</DataTableCell>
                                 <DataTableCell>

--- a/src/views/clusters/clusters-list.tsx
+++ b/src/views/clusters/clusters-list.tsx
@@ -1,6 +1,7 @@
 import { DataTable, DataTableBody as TableBody, DataTableCell, DataTableColumnHeader, DataTableHead as TableHead, DataTableRow } from '@dhis2/ui'
 import { FC } from 'react'
 import Moment from 'react-moment'
+import { Link } from 'react-router-dom'
 import { Heading } from '../../components/index.ts'
 import { useAuthAxios } from '../../hooks/index.ts'
 import { Cluster } from '../../types/index.ts'
@@ -29,7 +30,7 @@ export const ClustersList: FC = () => {
                     {data?.map((cluster: Cluster) => {
                         return (
                             <DataTableRow key={cluster.id}>
-                                <DataTableCell>{cluster.name}</DataTableCell>
+                                <DataTableCell><Link to={`/clusters/${cluster.id}`}>{cluster.name}</Link></DataTableCell>
                                 <DataTableCell>{cluster.description}</DataTableCell>
                                 <DataTableCell>{cluster.groups?.map((group) => group.name).join(', ')}</DataTableCell>
                                 <DataTableCell>

--- a/src/views/clusters/edit-cluster-modal.tsx
+++ b/src/views/clusters/edit-cluster-modal.tsx
@@ -51,7 +51,7 @@ export const EditClusterModal: FC<EditClusterModalProps> = ({ cluster, onComplet
             <ModalContent className={styles.container}>
                 <InputField className={styles.field} label="Name" value={name} onChange={({ value }) => setName(value)} required disabled={loading} />
                 <InputField className={styles.field} label="Description" value={description} onChange={({ value }) => setDescription(value)} required disabled={loading} />
-                <FileInput buttonLabel="Replace Kubernetes configuration (optional)" onChange={onFileSelect} disabled={loading} />
+                <FileInput buttonLabel="Replace Kubernetes configuration" onChange={onFileSelect} disabled={loading} />
             </ModalContent>
             <ModalActions>
                 <ButtonStrip end>

--- a/src/views/clusters/edit-cluster-modal.tsx
+++ b/src/views/clusters/edit-cluster-modal.tsx
@@ -1,0 +1,68 @@
+import { useAlert } from '@dhis2/app-service-alerts'
+import type { BaseButtonProps } from '@dhis2/ui'
+import { Button, ButtonStrip, FileInput, InputField, Modal, ModalActions, ModalContent, ModalTitle } from '@dhis2/ui'
+import type { FC } from 'react'
+import { useCallback, useState } from 'react'
+import { useAuthAxios } from '../../hooks/index.ts'
+import { Cluster } from '../../types/index.ts'
+import styles from './new-cluster-modal.module.css'
+
+type EditClusterModalProps = {
+    cluster: Cluster
+    onComplete: () => void
+    onCancel: BaseButtonProps['onClick']
+}
+
+export const EditClusterModal: FC<EditClusterModalProps> = ({ cluster, onComplete, onCancel }) => {
+    const [name, setName] = useState(cluster.name ?? '')
+    const [description, setDescription] = useState(cluster.description ?? '')
+    const [kubernetesConfiguration, setKubernetesConfiguration] = useState<File | null>(null)
+
+    const { show: showAlert } = useAlert(
+        ({ message }) => message,
+        ({ isCritical }) => (isCritical ? { critical: true } : { success: true })
+    )
+
+    const [{ loading }, updateCluster] = useAuthAxios<Cluster>({ url: `/clusters/${cluster.id}`, method: 'PUT' }, { manual: true })
+
+    const onFileSelect = useCallback(({ files }) => {
+        setKubernetesConfiguration(files[0] ?? null)
+    }, [])
+
+    const onSave = useCallback(async () => {
+        try {
+            const formData = new FormData()
+            formData.append('name', name)
+            formData.append('description', description)
+            if (kubernetesConfiguration) {
+                formData.append('kubernetesConfiguration', kubernetesConfiguration)
+            }
+            await updateCluster({ data: formData })
+            onComplete()
+        } catch (error) {
+            showAlert({ message: 'There was an error when updating the cluster', isCritical: true })
+            console.error(error)
+        }
+    }, [name, description, kubernetesConfiguration, updateCluster, onComplete, showAlert])
+
+    return (
+        <Modal onClose={() => onCancel({}, undefined satisfies React.MouseEvent<HTMLDivElement>)}>
+            <ModalTitle>Edit cluster</ModalTitle>
+            <ModalContent className={styles.container}>
+                <InputField className={styles.field} label="Name" value={name} onChange={({ value }) => setName(value)} required disabled={loading} />
+                <InputField className={styles.field} label="Description" value={description} onChange={({ value }) => setDescription(value)} required disabled={loading} />
+                <FileInput buttonLabel="Replace Kubernetes configuration (optional)" onChange={onFileSelect} disabled={loading} />
+            </ModalContent>
+            <ModalActions>
+                <ButtonStrip end>
+                    <Button onClick={onSave} disabled={loading} primary>
+                        Save
+                    </Button>
+                    <Button onClick={onCancel} disabled={loading}>
+                        Cancel
+                    </Button>
+                </ButtonStrip>
+            </ModalActions>
+        </Modal>
+    )
+}


### PR DESCRIPTION
Closes [DEVOPS-544](https://dhis2.atlassian.net/browse/DEVOPS-544).

Adds a details page for individual clusters at `/clusters/:id`, showing description, linked groups (with links to their detail pages), and timestamps. Cluster names in the list view are now clickable links to the details page. An edit modal allows admins to update the name, description, and optionally replace the kubeconfig file.