### PR TITLE
ci: use bare version tags without v prefix

### DIFF
--- a/.github/workflows/build-test-deploy.yaml
+++ b/.github/workflows/build-test-deploy.yaml
@@ -5,7 +5,7 @@ on:
         branches:
             - master
         tags:
-            - v*.*.*
+            - '[0-9]*'
 
     pull_request:
         types: [opened, reopened, synchronize, labeled]

--- a/README.md
+++ b/README.md
@@ -27,6 +27,18 @@ skaffold dev
     - Can submit without hostname... No effect, no error
 - Loading shows within form
 
+# Release
+
+Releasing is done by creating a new release tag (no `v` prefix).
+
+Example
+
+```shell
+git tag --sort=-creatordate | head --lines=1              # Get the latest tag
+git tag 0.35.0                                            # Use whichever tag you want to release
+git push origin 0.35.0
+```
+
 # Design
 
 - https://www.figma.com/proto/DOrik1KNpszSVrGFmChez3/Instance-manager?node-id=48-3665&starting-point-node-id=1%3A2


### PR DESCRIPTION
Switch to bare version tags (no v prefix) to match the merged dhis2-sre/gha-workflows#112: widen the deploy trigger to bare tags and document the release ritual in the README.