### PR TITLE
test: fix flaky e2e upload group-select leaving dropdown open

### DIFF
--- a/e2e/utils/upload-database.ts
+++ b/e2e/utils/upload-database.ts
@@ -16,10 +16,13 @@ export const uploadTestDatabase = async (page, dbName = defaultDbName) => {
 
     await expect(page.getByRole('button', { name: 'Select database' })).toBeVisible()
 
-    // Select the target group
+    // Select the target group. Use a real click on the option so @dhis2/ui closes its own
+    // dropdown layer; the previous dispatchEvent + Escape left the layer's backdrop mounted,
+    // which intercepted the "Select database" click once the e2e user belonged to >1 group.
     await page.getByTestId('dhis2-uiwidgets-singleselectfield').filter({ hasText: 'Group' }).getByTestId('dhis2-uicore-select-input').click()
-    await page.getByTestId('dhis2-uicore-singleselectoption').filter({ hasText: targetGroup }).dispatchEvent('click')
-    await page.keyboard.press('Escape') // dismiss dropdown layer
+    const groupOption = page.getByTestId('dhis2-uicore-singleselectoption').filter({ hasText: targetGroup })
+    await groupOption.click()
+    await expect(groupOption).toBeHidden() // dropdown layer must close before the next click
 
     const fileChooserPromise = page.waitForEvent('filechooser')
     await page.getByRole('button', { name: 'Select database' }).click()


### PR DESCRIPTION
The upload helper selected the group via dispatchEvent + Escape, which left the @dhis2/ui SingleSelect dropdown layer mounted; its backdrop intercepted the Select database click once the e2e user belonged to more than one group on dev, timing out all upload-based e2e tests since 2026-06-09. Switch to a real option click and wait for the dropdown to close. Verified the full e2e suite passes against api.im-dev.dhis2.org (4 passed, 1 skipped).