### PR TITLE
fix: repair Playwright e2e suite (react version mismatch + group select)

### DIFF
--- a/e2e/utils/upload-database.ts
+++ b/e2e/utils/upload-database.ts
@@ -16,13 +16,16 @@ export const uploadTestDatabase = async (page, dbName = defaultDbName) => {
 
     await expect(page.getByRole('button', { name: 'Select database' })).toBeVisible()
 
-    // Select the target group. Use a real click on the option so @dhis2/ui closes its own
-    // dropdown layer; the previous dispatchEvent + Escape left the layer's backdrop mounted,
-    // which intercepted the "Select database" click once the e2e user belonged to >1 group.
-    await page.getByTestId('dhis2-uiwidgets-singleselectfield').filter({ hasText: 'Group' }).getByTestId('dhis2-uicore-select-input').click()
-    const groupOption = page.getByTestId('dhis2-uicore-singleselectoption').filter({ hasText: targetGroup })
-    await groupOption.click()
-    await expect(groupOption).toBeHidden() // dropdown layer must close before the next click
+    // The group defaults to the e2e user's group; only open the dropdown to change it, since
+    // clicking an already-selected @dhis2/ui option is a no-op that leaves the layer's backdrop
+    // mounted, which then intercepts the "Select database" click.
+    const groupInput = page.getByTestId('dhis2-uiwidgets-singleselectfield').filter({ hasText: 'Group' }).getByTestId('dhis2-uicore-select-input')
+    const currentGroup = await groupInput.textContent()
+    if (!currentGroup?.includes(targetGroup)) {
+        await groupInput.click()
+        await page.getByTestId('dhis2-uicore-singleselectoption').filter({ hasText: targetGroup }).click()
+    }
+    await expect(page.getByTestId('dhis2-uicore-singleselectoption')).toHaveCount(0)
 
     const fileChooserPromise = page.waitForEvent('filechooser')
     await page.getByRole('button', { name: 'Select database' }).click()

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
         "moment": "^2.30.1",
         "pretty-bytes": "^7.1.0",
         "prop-types": "^15.8.1",
-        "react": "^19.2.6",
+        "react": "^19.2.7",
         "react-dom": "^19.2.7",
         "react-final-form": "^7.0.1",
         "react-moment": "^1.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7311,7 +7311,7 @@ __metadata:
     prettier: "npm:^3.8.3"
     pretty-bytes: "npm:^7.1.0"
     prop-types: "npm:^15.8.1"
-    react: "npm:^19.2.6"
+    react: "npm:^19.2.7"
     react-dom: "npm:^19.2.7"
     react-final-form: "npm:^7.0.1"
     react-moment: "npm:^1.1.3"
@@ -9474,10 +9474,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react@npm:^19.2.6":
-  version: 19.2.6
-  resolution: "react@npm:19.2.6"
-  checksum: 10c0/66afde33b9a9ee87b1e1cae39d8e7e040d1262e719524fd70660c4d4ce79929c532ac19fc3df5a911edaf02768fdf2c49de4ede1ba99bc6aad72796e0e26e798
+"react@npm:^19.2.7":
+  version: 19.2.7
+  resolution: "react@npm:19.2.7"
+  checksum: 10c0/0bd0e2f1bbd4ba97561c6597bf8a5fec05e6476fe61e165c1065598d16668efc6715205599c94d3ddd49d36cb0f21cbf1b9bcc18ee840b805ce222c3e8d558ac
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
The **Playwright Tests** suite has failed on every run since 2026-06-18, which fails the downstream `e2e` check on `dhis2-sre/im-manager` PRs. Two independent problems, both fixed here.

### 1. Login `beforeEach` timeout - react/react-dom version mismatch
Dependabot #832 bumped `react-dom` to `19.2.7` but left `react` at `19.2.6`. `react-dom@19.2.7` declares `peerDependencies: react ^19.2.7`, and react/react-dom share version-gated internals, so the mismatch breaks rendering at mount. The SPA never painted the login form, so every spec died in the shared login `beforeEach` hook (`waiting for getByRole('button', { name: 'Logout' })` / `getByLabel('email')`).

Bisected cleanly: last green `765a818`, first red `b816d12` (the react-dom bump, its only diff). Fix aligns `react` to `^19.2.7` and regenerates the lockfile so both resolve to `19.2.7`.

### 2. `toBeHidden` dropdown timeout - already-selected group
Once login worked, 3 specs failed in `uploadTestDatabase` at:
```
expect(getByTestId('dhis2-uicore-singleselectoption').filter({ hasText: 'whoami' })).toBeHidden()
```
The Group `SingleSelect` defaults to the e2e user's group (`whoami`), so the option is already selected. Clicking an already-selected `@dhis2/ui` option is a no-op that leaves the dropdown layer open, so the assertion timed out. This is environmental (reproduced on the last-green commit `765a818` against the current dev env), not caused by the react change.

`upload-database.ts` now only opens and picks the group when it isn't already the selected value, then asserts the option layer has closed.

### Verification
`e2e` check green: `4 passed, 1 skipped` (`stack.spec.ts` is a pre-existing `.skip`).