### PR TITLE
feat: components view with per-component and per-replica restart

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,1 +1,2 @@
 export type * from './generated'
+export type * from './instance-components.ts'

--- a/src/types/instance-components.ts
+++ b/src/types/instance-components.ts
@@ -1,0 +1,16 @@
+/* Hand-written types for GET /instances/:id/components (available from im-manager version-3.0).
+ * Regenerate-and-replace once the 3.0 swagger is published to the API the generated types are built from. */
+
+export type InstanceComponentReplica = {
+    name: string
+    phase: string
+    ready: boolean
+    restarts: number
+    createdAt: string
+}
+
+export type InstanceComponent = {
+    name: string
+    supportedOperations: string[]
+    replicas: InstanceComponentReplica[]
+}

--- a/src/views/groups/edit-group-modal.tsx
+++ b/src/views/groups/edit-group-modal.tsx
@@ -1,6 +1,19 @@
 import { useAlert } from '@dhis2/app-service-alerts'
 import type { BaseButtonProps } from '@dhis2/ui'
-import { Button, ButtonStrip, Center, CheckboxField, CircularLoader, InputField, Modal, ModalActions, ModalContent, ModalTitle, SingleSelectField, SingleSelectOption } from '@dhis2/ui'
+import {
+    Button,
+    ButtonStrip,
+    Center,
+    CheckboxField,
+    CircularLoader,
+    InputField,
+    Modal,
+    ModalActions,
+    ModalContent,
+    ModalTitle,
+    SingleSelectField,
+    SingleSelectOption,
+} from '@dhis2/ui'
 import cx from 'classnames'
 import type { FC } from 'react'
 import { useCallback, useState } from 'react'

--- a/src/views/groups/group-details.tsx
+++ b/src/views/groups/group-details.tsx
@@ -1,4 +1,16 @@
-import { Button, Center, CircularLoader, DataTable, DataTableBody as TableBody, DataTableCell, DataTableColumnHeader, DataTableHead as TableHead, DataTableRow, IconCheckmark16, NoticeBox } from '@dhis2/ui'
+import {
+    Button,
+    Center,
+    CircularLoader,
+    DataTable,
+    DataTableBody as TableBody,
+    DataTableCell,
+    DataTableColumnHeader,
+    DataTableHead as TableHead,
+    DataTableRow,
+    IconCheckmark16,
+    NoticeBox,
+} from '@dhis2/ui'
 import type { FC } from 'react'
 import { useState } from 'react'
 import Moment from 'react-moment'
@@ -66,15 +78,11 @@ export const GroupDetails: FC = () => {
                     </DataTableRow>
                     <DataTableRow>
                         <DataTableCell>Created</DataTableCell>
-                        <DataTableCell>
-                            {group?.createdAt && <Moment date={group.createdAt} fromNow />}
-                        </DataTableCell>
+                        <DataTableCell>{group?.createdAt && <Moment date={group.createdAt} fromNow />}</DataTableCell>
                     </DataTableRow>
                     <DataTableRow>
                         <DataTableCell>Updated</DataTableCell>
-                        <DataTableCell>
-                            {group?.updatedAt && <Moment date={group.updatedAt} fromNow />}
-                        </DataTableCell>
+                        <DataTableCell>{group?.updatedAt && <Moment date={group.updatedAt} fromNow />}</DataTableCell>
                     </DataTableRow>
                 </TableBody>
             </DataTable>

--- a/src/views/groups/groups-list.tsx
+++ b/src/views/groups/groups-list.tsx
@@ -32,7 +32,9 @@ export const GroupsList: FC = () => {
                 <TableBody>
                     {data?.map((group) => (
                         <DataTableRow key={group.name}>
-                            <DataTableCell><Link to={`/groups/${group.name}`}>{group.name}</Link></DataTableCell>
+                            <DataTableCell>
+                                <Link to={`/groups/${group.name}`}>{group.name}</Link>
+                            </DataTableCell>
                             <DataTableCell>{group.namespace}</DataTableCell>
                             <DataTableCell>{group.hostname}</DataTableCell>
                             <DataTableCell>{group.description}</DataTableCell>

--- a/src/views/instances/details/deployment-instances-list.tsx
+++ b/src/views/instances/details/deployment-instances-list.tsx
@@ -1,5 +1,6 @@
 import { DataTable, DataTableBody, DataTableCell, DataTableColumnHeader, DataTableHead, DataTableRow } from '@dhis2/ui'
 import type { RefetchFunction } from 'axios-hooks'
+import { useState } from 'react'
 import type { FC } from 'react'
 import Moment from 'react-moment'
 import { useNavigate } from 'react-router-dom'
@@ -8,6 +9,7 @@ import { Deployment } from '../../../types/index.ts'
 import styles from '../list/instances-list.module.css'
 import { Dhis2StackName } from '../new-dhis2/parameter-fieldset.tsx'
 import { ActionsDropdownMenu } from './actions-dropdown-menu.tsx'
+import { InstanceComponents } from './instance-components.tsx'
 import { StatusLabel } from './status-label.tsx'
 import { ViewInstanceMenuItem } from './view-instance-menu-item.tsx'
 
@@ -18,6 +20,18 @@ export const DeploymentInstancesList: FC<{
     loading: boolean
 }> = ({ deployment, refetch, loading }) => {
     const navigate = useNavigate()
+    const [expandedInstances, setExpandedInstances] = useState<Set<number>>(new Set())
+    const toggleExpanded = (instanceId: number, expanded: boolean) => {
+        setExpandedInstances((current) => {
+            const next = new Set(current)
+            if (expanded) {
+                next.add(instanceId)
+            } else {
+                next.delete(instanceId)
+            }
+            return next
+        })
+    }
     return (
         <DataTable>
             <DataTableHead>
@@ -34,7 +48,17 @@ export const DeploymentInstancesList: FC<{
                 {deployment.instances?.map((instance) => {
                     const onClick = () => navigate(`/instance/${instance.id}/details`)
                     return (
-                        <tr className={styles.clickableRow} key={instance.id}>
+                        <DataTableRow
+                            className={styles.clickableRow}
+                            key={instance.id}
+                            expanded={expandedInstances.has(instance.id)}
+                            onExpandToggle={({ expanded }) => toggleExpanded(instance.id, expanded)}
+                            expandableContent={
+                                <div className={styles.expandedComponents}>
+                                    <InstanceComponents instanceId={instance.id} />
+                                </div>
+                            }
+                        >
                             <DataTableCell staticStyle onClick={onClick}>
                                 <StatusLabel instanceId={instance.id} />
                             </DataTableCell>
@@ -60,7 +84,7 @@ export const DeploymentInstancesList: FC<{
                             <DataTableCell staticStyle align="right">
                                 <ActionsDropdownMenu deploymentId={deployment.id} instanceId={instance.id} stackName={instance.stackName as Dhis2StackName} refetch={refetch} />
                             </DataTableCell>
-                        </tr>
+                        </DataTableRow>
                     )
                 })}
             </DataTableBody>

--- a/src/views/instances/details/instance-components.module.css
+++ b/src/views/instances/details/instance-components.module.css
@@ -1,0 +1,10 @@
+.header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin: 16px 0 8px;
+}
+
+.header h3 {
+    margin: 0;
+}

--- a/src/views/instances/details/instance-components.module.css
+++ b/src/views/instances/details/instance-components.module.css
@@ -8,3 +8,16 @@
 .header h3 {
     margin: 0;
 }
+
+.loading {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 16px 0;
+    color: rgba(0, 0, 0, 0.6);
+}
+
+.empty {
+    padding: 8px 0;
+    color: rgba(0, 0, 0, 0.6);
+}

--- a/src/views/instances/details/instance-components.tsx
+++ b/src/views/instances/details/instance-components.tsx
@@ -1,5 +1,5 @@
 import { useAlert } from '@dhis2/app-service-alerts'
-import { Button, DataTable, DataTableBody, DataTableCell, DataTableColumnHeader, DataTableHead, DataTableRow, IconSync16, Tag } from '@dhis2/ui'
+import { Button, CircularLoader, DataTable, DataTableBody, DataTableCell, DataTableColumnHeader, DataTableHead, DataTableRow, IconSync16, Tag } from '@dhis2/ui'
 import { Fragment, useCallback, useState } from 'react'
 import type { FC } from 'react'
 import Moment from 'react-moment'
@@ -58,10 +58,25 @@ export const InstanceComponents: FC<{ instanceId: number }> = ({ instanceId }) =
         }
     }, [restartTarget, restart, showAlert, refetch])
 
-    /* Instances deployed against a pre-3.0 backend (or stacks without components) have nothing to
-     * show here; hide the section instead of surfacing the error. */
-    if (error || (!loading && (!components || components.length === 0))) {
+    /* Instances deployed against a pre-3.0 backend have nothing to show here; hide the section
+     * instead of surfacing the error. */
+    if (error) {
         return null
+    }
+
+    /* The listing queries the cluster for every component's replicas, so it is slow by nature;
+     * show that something is happening rather than nothing. */
+    if (loading && !components) {
+        return (
+            <div className={styles.loading} data-test="instance-components-loading">
+                <CircularLoader small />
+                <span>Fetching components from the cluster...</span>
+            </div>
+        )
+    }
+
+    if (!loading && (!components || components.length === 0)) {
+        return <p className={styles.empty}>No components</p>
     }
 
     return (

--- a/src/views/instances/details/instance-components.tsx
+++ b/src/views/instances/details/instance-components.tsx
@@ -1,0 +1,160 @@
+import { useAlert } from '@dhis2/app-service-alerts'
+import { Button, DataTable, DataTableBody, DataTableCell, DataTableColumnHeader, DataTableHead, DataTableRow, IconSync16, Tag } from '@dhis2/ui'
+import { Fragment, useCallback, useState } from 'react'
+import type { FC } from 'react'
+import Moment from 'react-moment'
+import { ConfirmationModal } from '../../../components/index.ts'
+import { useAuthAxios } from '../../../hooks/index.ts'
+import { InstanceComponent, InstanceComponentReplica } from '../../../types/index.ts'
+import styles from './instance-components.module.css'
+
+const getReplicaTagProps = (replica: InstanceComponentReplica) => {
+    if (replica.phase === 'Failed') {
+        return { negative: true }
+    }
+    if (replica.phase === 'Running' && replica.ready) {
+        return { positive: true }
+    }
+    return { neutral: true }
+}
+
+type RestartTarget = {
+    selector: string
+    replica?: string
+}
+
+const describeTarget = (target: RestartTarget) => (target.replica ? `replica "${target.replica}" of component "${target.selector}"` : `component "${target.selector}"`)
+
+export const InstanceComponents: FC<{ instanceId: number }> = ({ instanceId }) => {
+    const [{ data: components, loading, error }, refetch] = useAuthAxios<InstanceComponent[]>({ url: `/instances/${instanceId}/components` }, { useCache: false, autoCatch: true })
+    const [restartTarget, setRestartTarget] = useState<RestartTarget | null>(null)
+
+    const { show: showAlert } = useAlert(
+        ({ message }) => message,
+        ({ isCritical }) => (isCritical ? { critical: true } : { success: true })
+    )
+
+    const [{ loading: restarting }, restart] = useAuthAxios(
+        {
+            method: 'PUT',
+            url: `/instances/${instanceId}/restart`,
+        },
+        { manual: true, autoCancel: false }
+    )
+
+    const onConfirmRestart = useCallback(async () => {
+        const target = restartTarget
+        setRestartTarget(null)
+        if (!target) {
+            return
+        }
+        try {
+            await restart({ params: target })
+            showAlert({ message: `Successfully requested restart of ${describeTarget(target)}`, isCritical: false })
+            refetch()
+        } catch (restartError) {
+            showAlert({ message: `There was an error when restarting ${describeTarget(target)}`, isCritical: true })
+            console.error(restartError)
+        }
+    }, [restartTarget, restart, showAlert, refetch])
+
+    /* Instances deployed against a pre-3.0 backend (or stacks without components) have nothing to
+     * show here; hide the section instead of surfacing the error. */
+    if (error || (!loading && (!components || components.length === 0))) {
+        return null
+    }
+
+    return (
+        <>
+            {restartTarget && (
+                <ConfirmationModal onCancel={() => setRestartTarget(null)} onConfirm={onConfirmRestart}>
+                    Are you sure you want to restart {describeTarget(restartTarget)}?
+                </ConfirmationModal>
+            )}
+            <div className={styles.header}>
+                <h3>Components</h3>
+                <Button small onClick={() => refetch()} loading={loading} dataTest="refresh-components-button">
+                    Refresh
+                </Button>
+            </div>
+            <DataTable dataTest="instance-components">
+                <DataTableHead>
+                    <DataTableRow>
+                        <DataTableColumnHeader>Component</DataTableColumnHeader>
+                        <DataTableColumnHeader>Replica</DataTableColumnHeader>
+                        <DataTableColumnHeader>Status</DataTableColumnHeader>
+                        <DataTableColumnHeader>Restarts</DataTableColumnHeader>
+                        <DataTableColumnHeader>Created</DataTableColumnHeader>
+                        <DataTableColumnHeader></DataTableColumnHeader>
+                    </DataTableRow>
+                </DataTableHead>
+                <DataTableBody loading={loading}>
+                    {(components ?? []).map((component) => (
+                        <Fragment key={component.name}>
+                            <DataTableRow>
+                                <DataTableCell staticStyle>{component.name}</DataTableCell>
+                                <DataTableCell></DataTableCell>
+                                <DataTableCell>
+                                    {component.supportedOperations.map((operation) => (
+                                        <Tag key={operation}>{operation}</Tag>
+                                    ))}
+                                </DataTableCell>
+                                <DataTableCell></DataTableCell>
+                                <DataTableCell></DataTableCell>
+                                <DataTableCell>
+                                    {component.supportedOperations.includes('restart') && (
+                                        <Button
+                                            small
+                                            icon={<IconSync16 />}
+                                            disabled={restarting}
+                                            onClick={() => setRestartTarget({ selector: component.name })}
+                                            dataTest={`restart-component-${component.name}`}
+                                        >
+                                            Restart
+                                        </Button>
+                                    )}
+                                </DataTableCell>
+                            </DataTableRow>
+                            {component.replicas.map((replica) => (
+                                <DataTableRow key={replica.name}>
+                                    <DataTableCell></DataTableCell>
+                                    <DataTableCell staticStyle>{replica.name}</DataTableCell>
+                                    <DataTableCell>
+                                        <Tag {...getReplicaTagProps(replica)}>{replica.ready ? replica.phase : `${replica.phase} (not ready)`}</Tag>
+                                    </DataTableCell>
+                                    <DataTableCell>{replica.restarts}</DataTableCell>
+                                    <DataTableCell>
+                                        <Moment date={replica.createdAt} fromNow />
+                                    </DataTableCell>
+                                    <DataTableCell>
+                                        {component.supportedOperations.includes('restartReplica') && (
+                                            <Button
+                                                small
+                                                icon={<IconSync16 />}
+                                                disabled={restarting}
+                                                onClick={() => setRestartTarget({ selector: component.name, replica: replica.name })}
+                                                dataTest={`restart-replica-${replica.name}`}
+                                            >
+                                                Restart replica
+                                            </Button>
+                                        )}
+                                    </DataTableCell>
+                                </DataTableRow>
+                            ))}
+                            {component.replicas.length === 0 && (
+                                <DataTableRow>
+                                    <DataTableCell></DataTableCell>
+                                    <DataTableCell>No replicas</DataTableCell>
+                                    <DataTableCell></DataTableCell>
+                                    <DataTableCell></DataTableCell>
+                                    <DataTableCell></DataTableCell>
+                                    <DataTableCell></DataTableCell>
+                                </DataTableRow>
+                            )}
+                        </Fragment>
+                    ))}
+                </DataTableBody>
+            </DataTable>
+        </>
+    )
+}

--- a/src/views/instances/details/instance-details.tsx
+++ b/src/views/instances/details/instance-details.tsx
@@ -5,6 +5,7 @@ import { Heading } from '../../../components/index.ts'
 import { useAuthAxios, useStack } from '../../../hooks/index.ts'
 import { DeploymentInstance, StackParameter } from '../../../types/index.ts'
 import styles from '../list/instances-list.module.css'
+import { InstanceComponents } from './instance-components.tsx'
 import { InstanceSummary } from './instance-summary.tsx'
 
 export const InstanceDetails = () => {
@@ -41,6 +42,7 @@ export const InstanceDetails = () => {
                     <InstanceSummary instance={instance} />
                 </Card>
             </div>
+            <InstanceComponents instanceId={instance.id} />
             <br />
             <DataTable>
                 <DataTableHead>

--- a/src/views/instances/list/instances-list.module.css
+++ b/src/views/instances/list/instances-list.module.css
@@ -42,3 +42,4 @@ td {
     margin-right: 0;
     margin-bottom: 0;
 }
+.expandedComponents { padding: 8px 16px 16px; }


### PR DESCRIPTION
Targets version-3.0, pairing with im-manager's version-3.0 branch (dhis2-sre/im-manager#1620). The instance details page gains a Components section driven by the new GET /instances/:id/components endpoint: each component shows its supported operations as tags and its live replicas with phase, readiness, restart count and age. Components with the restart operation get a restart button (PUT /instances/:id/restart?selector=), and each replica gets a restart button using the new replica parameter, both behind the existing confirmation modal. The section hides itself when the endpoint errors or returns no components, so the page still works against a pre-3.0 backend. Types for the new endpoint are hand-written next to the generated ones until the 3.0 swagger is published where generate-types points. The style commit formats three groups views that drifted from the current prettier config on master.

Also adds a deployment-level view: on the deployment details page every instance row is expandable, and expanding it fetches and shows that instance's components with their replicas and restart actions. The fetch queries the cluster per component so it is slow by nature; a spinner with 'Fetching components from the cluster...' provides feedback while it loads, and the fetch only happens when a row is expanded.