### PR TITLE
refactor: split the compose file into a deployment base and a dev overlay

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,5 +1,10 @@
 dotenv
 
+# docker-compose.yml is the deployment base and deliberately has no ports and no build. Stacking the
+# dev file here means `docker compose ...` behaves as it always has locally, while a server passes
+# its own -f flags and never picks this up.
+export COMPOSE_FILE=docker-compose.yml:docker-compose.dev.yml
+
 if [ "$CLASSIFICATION" = "prod" ]; then
   export API_HOSTNAME=api.im.dhis2.org
   export UI_HOSTNAME=im.dhis2.org

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,10 @@
 SHELL := /bin/bash
+
+# Every target needs the dev overlay: the build contexts, the published ports and the dev and test
+# services all live there. .envrc exports this as well for bare docker compose calls, but CI runs
+# these targets without direnv.
+export COMPOSE_FILE ?= docker-compose.yml:docker-compose.dev.yml
+
 tag ?= latest
 version ?= $(shell yq e '.version' helm/chart/Chart.yaml)
 clean-cmd = docker compose down --remove-orphans --volumes

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,59 @@
+# Local development on top of docker-compose.yml: the image built from source, published ports, and
+# the development and test services. .envrc puts this in COMPOSE_FILE; servers pass explicit -f
+# flags and never see it.
+services:
+  prod:
+    build: .
+    ports:
+      - "8080:8080"
+
+  dev:
+    build:
+      context: .
+      target: builder
+    environment:
+      API_URL: ${API_URL}
+    stdin_open: true
+    tty: true
+    volumes:
+      - .:/src
+    working_dir: /src
+    command: yarn start
+    ports:
+      - "3000:3000"
+
+  e2e-test:
+    image: mcr.microsoft.com/playwright:v1.60.0-noble
+    stdin_open: true
+    tty: true
+    command: >
+      sh -c "
+        set -e
+        corepack enable
+        corepack prepare yarn@stable --activate
+        yarn install --immutable
+        yarn playwright test
+      "
+    network_mode: host
+    volumes:
+      - ./:/e2e
+    working_dir: /e2e
+    environment:
+      CI: "true"
+      USER_EMAIL: ${USER_EMAIL}
+      USER_PASSWORD: ${USER_PASSWORD}
+      API_URL: ${API_URL}
+      VITE_API_URL: ${API_URL}
+
+  test:
+    build:
+      context: .
+      target: builder
+    environment:
+      API_URL: ${API_URL}
+    stdin_open: true
+    tty: true
+    volumes:
+      - .:/src
+    working_dir: /src
+    command: sh -c "yarn install --frozen-lockfile && yarn test -- --watchAll=false"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,59 +1,11 @@
+# The deployment base: no published ports and nothing built from source, so a server can use it
+# verbatim. .envrc adds docker-compose.dev.yml through COMPOSE_FILE for local use.
+#
+# dhis2-infrastructure runs this as its own compose project per environment, alongside the im-manager
+# one, both joined to a shared ingress network.
 services:
-    prod:
-        image: dhis2/im-web-client:${IMAGE_TAG:-latest}
-        build: .
-        environment:
-            API_URL: ${API_URL}
-        ports:
-            - "8080:8080"
-
-    dev:
-        build:
-            context: .
-            target: builder
-        environment:
-            API_URL: ${API_URL}
-        stdin_open: true
-        tty: true
-        volumes:
-            - .:/src
-        working_dir: /src
-        command: yarn start
-        ports:
-            - "3000:3000"
-
-    e2e-test:
-        image: mcr.microsoft.com/playwright:v1.60.0-noble
-        stdin_open: true
-        tty: true
-        command: >
-            sh -c "
-              set -e
-              corepack enable
-              corepack prepare yarn@stable --activate
-              yarn install --immutable
-              yarn playwright test
-            "
-        network_mode: host
-        volumes:
-            - ./:/e2e
-        working_dir: /e2e
-        environment:
-            CI: "true"
-            USER_EMAIL: ${USER_EMAIL}
-            USER_PASSWORD: ${USER_PASSWORD}
-            API_URL: ${API_URL}
-            VITE_API_URL: ${API_URL}
-
-    test:
-        build:
-            context: .
-            target: builder
-        environment:
-            API_URL: ${API_URL}
-        stdin_open: true
-        tty: true
-        volumes:
-            - .:/src
-        working_dir: /src
-        command: sh -c "yarn install --frozen-lockfile && yarn test -- --watchAll=false"
+  prod:
+    image: dhis2/im-web-client:${IMAGE_TAG:-latest}
+    # Substituted into the built assets by the entrypoint, so one image serves every environment.
+    environment:
+      API_URL: ${API_URL}


### PR DESCRIPTION
`docker-compose.yml` becomes the deployment base: no published ports and no `build:`, so a server can use it verbatim. `docker-compose.dev.yml` restores the build, the ports and the development and test services, and is stacked through `COMPOSE_FILE` in `.envrc`, so `docker compose ...` and every make target behave exactly as before.

No service is renamed and the `Makefile` is untouched: dhis2-infrastructure runs this as a compose project of its own rather than merging it with im-manager's file, so the two repositories never share a namespace.

Pairs with dhis2-sre/im-manager#1636.