### PR TITLE
fix: do not mask login errors with a refresh attempt

### DIFF
--- a/src/hooks/use-auth-axios.ts
+++ b/src/hooks/use-auth-axios.ts
@@ -42,7 +42,12 @@ const refreshTokens = () => {
 axiosInstance.interceptors.response.use(
     (response) => response,
     async (error: AxiosError) => {
-        if (error.response?.status !== 401) {
+        /* Only try to refresh an expired session. A 401 from the login itself means bad
+         * credentials, and a 401 from the refresh endpoint means the session is gone; refreshing
+         * in those cases masks the real error (e.g. "invalid email and password combination"
+         * became "refresh token not found"). */
+        const requestUrl = error.config?.url ?? ''
+        if (error.response?.status !== 401 || requestUrl.endsWith('/tokens') || requestUrl.endsWith('/refresh')) {
             return Promise.reject(error)
         }
 


### PR DESCRIPTION
The response interceptor treated every 401 as an expired session, including the 401 from the login request itself, and then surfaced the refresh failure instead of the original error: a wrong or unknown password showed as refresh token not found rather than invalid email and password combination. The refresh attempt now only happens for 401s that are not from the token or refresh endpoints. Found logging in fresh on the version-3-0 environment, where personal accounts from other environments do not exist.