### PR TITLE
feat: deployment level component view with operation menus

### DIFF
--- a/src/types/instance-components.ts
+++ b/src/types/instance-components.ts
@@ -14,3 +14,10 @@ export type InstanceComponent = {
     supportedOperations: string[]
     replicas: InstanceComponentReplica[]
 }
+
+export type DeploymentInstanceComponents = {
+    instanceId: number
+    instanceName: string
+    stackName: string
+    components: InstanceComponent[]
+}

--- a/src/views/instances/details/component-operations-menu.tsx
+++ b/src/views/instances/details/component-operations-menu.tsx
@@ -1,0 +1,103 @@
+import { useAlert } from '@dhis2/app-service-alerts'
+import { Button, IconMore24, Menu, MenuItem, Popover } from '@dhis2/ui'
+import { useCallback, useRef, useState } from 'react'
+import type { FC } from 'react'
+import { ConfirmationModal } from '../../../components/index.ts'
+import { useAuthAxios } from '../../../hooks/index.ts'
+import { InstanceComponent } from '../../../types/index.ts'
+
+type RestartTarget = {
+    selector: string
+    replica?: string
+}
+
+const describeTarget = (target: RestartTarget) => (target.replica ? `replica "${target.replica}" of component "${target.selector}"` : `component "${target.selector}"`)
+
+/* Operations the menu knows how to perform; every other advertised operation is shown disabled so
+ * capabilities stay visible until they get an action here. */
+const actionableOperations = ['restart', 'restartReplica']
+
+export const ComponentOperationsMenu: FC<{
+    instanceId: number
+    component: InstanceComponent
+    onChanged: () => void
+}> = ({ instanceId, component, onChanged }) => {
+    const anchor = useRef<HTMLSpanElement>(null)
+    const [open, setOpen] = useState(false)
+    const [restartTarget, setRestartTarget] = useState<RestartTarget | null>(null)
+
+    const { show: showAlert } = useAlert(
+        ({ message }) => message,
+        ({ isCritical }) => (isCritical ? { critical: true } : { success: true })
+    )
+
+    const [{ loading: restarting }, restart] = useAuthAxios(
+        {
+            method: 'PUT',
+            url: `/instances/${instanceId}/restart`,
+        },
+        { manual: true, autoCancel: false }
+    )
+
+    const confirmTarget = (target: RestartTarget) => {
+        setOpen(false)
+        setRestartTarget(target)
+    }
+
+    const onConfirmRestart = useCallback(async () => {
+        const target = restartTarget
+        setRestartTarget(null)
+        if (!target) {
+            return
+        }
+        try {
+            await restart({ params: target })
+            showAlert({ message: `Successfully requested restart of ${describeTarget(target)}`, isCritical: false })
+            onChanged()
+        } catch (restartError) {
+            showAlert({ message: `There was an error when restarting ${describeTarget(target)}`, isCritical: true })
+            console.error(restartError)
+        }
+    }, [restartTarget, restart, showAlert, onChanged])
+
+    return (
+        <>
+            {restartTarget && (
+                <ConfirmationModal onCancel={() => setRestartTarget(null)} onConfirm={onConfirmRestart}>
+                    Are you sure you want to restart {describeTarget(restartTarget)}?
+                </ConfirmationModal>
+            )}
+            <span ref={anchor}>
+                <Button
+                    small
+                    secondary
+                    loading={restarting}
+                    icon={<IconMore24 />}
+                    onClick={() => setOpen((current) => !current)}
+                    dataTest={`component-operations-${component.name}`}
+                />
+            </span>
+            {open && (
+                <Popover onClickOutside={() => setOpen(false)} reference={anchor} placement="bottom-start">
+                    <Menu>
+                        {component.supportedOperations.includes('restart') && <MenuItem dense label="Restart" onClick={() => confirmTarget({ selector: component.name })} />}
+                        {component.supportedOperations.includes('restartReplica') &&
+                            component.replicas.map((replica) => (
+                                <MenuItem
+                                    dense
+                                    key={replica.name}
+                                    label={`Restart replica ${replica.name}`}
+                                    onClick={() => confirmTarget({ selector: component.name, replica: replica.name })}
+                                />
+                            ))}
+                        {component.supportedOperations
+                            .filter((operation) => !actionableOperations.includes(operation))
+                            .map((operation) => (
+                                <MenuItem dense key={operation} label={operation} disabled />
+                            ))}
+                    </Menu>
+                </Popover>
+            )}
+        </>
+    )
+}

--- a/src/views/instances/details/components-table.tsx
+++ b/src/views/instances/details/components-table.tsx
@@ -1,0 +1,79 @@
+import { DataTable, DataTableBody, DataTableCell, DataTableColumnHeader, DataTableHead, DataTableRow, Tag } from '@dhis2/ui'
+import { Fragment } from 'react'
+import type { FC } from 'react'
+import Moment from 'react-moment'
+import { InstanceComponent, InstanceComponentReplica } from '../../../types/index.ts'
+import { ComponentOperationsMenu } from './component-operations-menu.tsx'
+
+const getReplicaTagProps = (replica: InstanceComponentReplica) => {
+    if (replica.phase === 'Failed') {
+        return { negative: true }
+    }
+    if (replica.phase === 'Running' && replica.ready) {
+        return { positive: true }
+    }
+    return { neutral: true }
+}
+
+export const ComponentsTable: FC<{
+    instanceId: number
+    components: InstanceComponent[]
+    onChanged: () => void
+}> = ({ instanceId, components, onChanged }) => (
+    <DataTable dataTest="instance-components">
+        <DataTableHead>
+            <DataTableRow>
+                <DataTableColumnHeader>Component</DataTableColumnHeader>
+                <DataTableColumnHeader>Replica</DataTableColumnHeader>
+                <DataTableColumnHeader>Status</DataTableColumnHeader>
+                <DataTableColumnHeader>Restarts</DataTableColumnHeader>
+                <DataTableColumnHeader>Created</DataTableColumnHeader>
+                <DataTableColumnHeader></DataTableColumnHeader>
+            </DataTableRow>
+        </DataTableHead>
+        <DataTableBody>
+            {components.map((component) => (
+                <Fragment key={component.name}>
+                    <DataTableRow>
+                        <DataTableCell staticStyle>{component.name}</DataTableCell>
+                        <DataTableCell></DataTableCell>
+                        <DataTableCell>
+                            {component.supportedOperations.map((operation) => (
+                                <Tag key={operation}>{operation}</Tag>
+                            ))}
+                        </DataTableCell>
+                        <DataTableCell></DataTableCell>
+                        <DataTableCell></DataTableCell>
+                        <DataTableCell align="right">
+                            <ComponentOperationsMenu instanceId={instanceId} component={component} onChanged={onChanged} />
+                        </DataTableCell>
+                    </DataTableRow>
+                    {component.replicas.map((replica) => (
+                        <DataTableRow key={replica.name}>
+                            <DataTableCell></DataTableCell>
+                            <DataTableCell staticStyle>{replica.name}</DataTableCell>
+                            <DataTableCell>
+                                <Tag {...getReplicaTagProps(replica)}>{replica.ready ? replica.phase : `${replica.phase} (not ready)`}</Tag>
+                            </DataTableCell>
+                            <DataTableCell>{replica.restarts}</DataTableCell>
+                            <DataTableCell>
+                                <Moment date={replica.createdAt} fromNow />
+                            </DataTableCell>
+                            <DataTableCell></DataTableCell>
+                        </DataTableRow>
+                    ))}
+                    {component.replicas.length === 0 && (
+                        <DataTableRow>
+                            <DataTableCell></DataTableCell>
+                            <DataTableCell>No replicas</DataTableCell>
+                            <DataTableCell></DataTableCell>
+                            <DataTableCell></DataTableCell>
+                            <DataTableCell></DataTableCell>
+                            <DataTableCell></DataTableCell>
+                        </DataTableRow>
+                    )}
+                </Fragment>
+            ))}
+        </DataTableBody>
+    </DataTable>
+)

--- a/src/views/instances/details/deployment-components.tsx
+++ b/src/views/instances/details/deployment-components.tsx
@@ -1,0 +1,47 @@
+import { Button, CircularLoader } from '@dhis2/ui'
+import type { FC } from 'react'
+import { useAuthAxios } from '../../../hooks/index.ts'
+import { DeploymentInstanceComponents } from '../../../types/index.ts'
+import { ComponentsTable } from './components-table.tsx'
+import styles from './instance-components.module.css'
+
+export const DeploymentComponents: FC<{ deploymentId: number }> = ({ deploymentId }) => {
+    const [{ data: instances, loading, error }, refetch] = useAuthAxios<DeploymentInstanceComponents[]>(
+        { url: `/deployments/${deploymentId}/components` },
+        { useCache: false, autoCatch: true }
+    )
+
+    if (error) {
+        return null
+    }
+
+    /* The listing queries the cluster for every component of every instance, so it is slow by
+     * nature; show that something is happening rather than nothing. */
+    if (loading && !instances) {
+        return (
+            <div className={styles.loading} data-test="deployment-components-loading">
+                <CircularLoader small />
+                <span>Fetching components from the cluster...</span>
+            </div>
+        )
+    }
+
+    return (
+        <>
+            <div className={styles.header}>
+                <h3>Components</h3>
+                <Button small onClick={() => refetch()} loading={loading} dataTest="refresh-components-button">
+                    Refresh
+                </Button>
+            </div>
+            {(instances ?? []).map((instance) => (
+                <div key={instance.instanceId} className={styles.instanceComponents}>
+                    <h4 className={styles.instanceTitle}>
+                        {instance.instanceName} ({instance.stackName})
+                    </h4>
+                    <ComponentsTable instanceId={instance.instanceId} components={instance.components} onChanged={refetch} />
+                </div>
+            ))}
+        </>
+    )
+}

--- a/src/views/instances/details/deployment-details.tsx
+++ b/src/views/instances/details/deployment-details.tsx
@@ -3,6 +3,7 @@ import { FC } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { Heading } from '../../../components/index.ts'
 import { useDeploymentDetails } from '../../../hooks/index.ts'
+import { DeploymentComponents } from './deployment-components.tsx'
 import styles from './deployment-details.module.css'
 import { DeploymentInstancesList } from './deployment-instances-list.tsx'
 import { DeploymentSummary } from './deployment-summary.tsx'
@@ -42,6 +43,7 @@ export const DeploymentDetails: FC = () => {
                         <NoticeBox title="No stacks connected to this instance">Currently you can only add components to an instance when creating one.</NoticeBox>
                     )}
                     {deployment?.instances?.length > 0 && <DeploymentInstancesList deployment={deployment} refetch={refetch} loading={loading} />}
+                    {deployment?.instances?.length > 0 && <DeploymentComponents deploymentId={deployment.id} />}
                 </>
             )}
         </div>

--- a/src/views/instances/details/deployment-instances-list.tsx
+++ b/src/views/instances/details/deployment-instances-list.tsx
@@ -1,6 +1,5 @@
 import { DataTable, DataTableBody, DataTableCell, DataTableColumnHeader, DataTableHead, DataTableRow } from '@dhis2/ui'
 import type { RefetchFunction } from 'axios-hooks'
-import { useState } from 'react'
 import type { FC } from 'react'
 import Moment from 'react-moment'
 import { useNavigate } from 'react-router-dom'
@@ -9,7 +8,6 @@ import { Deployment } from '../../../types/index.ts'
 import styles from '../list/instances-list.module.css'
 import { Dhis2StackName } from '../new-dhis2/parameter-fieldset.tsx'
 import { ActionsDropdownMenu } from './actions-dropdown-menu.tsx'
-import { InstanceComponents } from './instance-components.tsx'
 import { StatusLabel } from './status-label.tsx'
 import { ViewInstanceMenuItem } from './view-instance-menu-item.tsx'
 
@@ -20,18 +18,6 @@ export const DeploymentInstancesList: FC<{
     loading: boolean
 }> = ({ deployment, refetch, loading }) => {
     const navigate = useNavigate()
-    const [expandedInstances, setExpandedInstances] = useState<Set<number>>(new Set())
-    const toggleExpanded = (instanceId: number, expanded: boolean) => {
-        setExpandedInstances((current) => {
-            const next = new Set(current)
-            if (expanded) {
-                next.add(instanceId)
-            } else {
-                next.delete(instanceId)
-            }
-            return next
-        })
-    }
     return (
         <DataTable>
             <DataTableHead>
@@ -48,17 +34,7 @@ export const DeploymentInstancesList: FC<{
                 {deployment.instances?.map((instance) => {
                     const onClick = () => navigate(`/instance/${instance.id}/details`)
                     return (
-                        <DataTableRow
-                            className={styles.clickableRow}
-                            key={instance.id}
-                            expanded={expandedInstances.has(instance.id)}
-                            onExpandToggle={({ expanded }) => toggleExpanded(instance.id, expanded)}
-                            expandableContent={
-                                <div className={styles.expandedComponents}>
-                                    <InstanceComponents instanceId={instance.id} />
-                                </div>
-                            }
-                        >
+                        <tr className={styles.clickableRow} key={instance.id}>
                             <DataTableCell staticStyle onClick={onClick}>
                                 <StatusLabel instanceId={instance.id} />
                             </DataTableCell>
@@ -84,7 +60,7 @@ export const DeploymentInstancesList: FC<{
                             <DataTableCell staticStyle align="right">
                                 <ActionsDropdownMenu deploymentId={deployment.id} instanceId={instance.id} stackName={instance.stackName as Dhis2StackName} refetch={refetch} />
                             </DataTableCell>
-                        </DataTableRow>
+                        </tr>
                     )
                 })}
             </DataTableBody>

--- a/src/views/instances/details/instance-components.module.css
+++ b/src/views/instances/details/instance-components.module.css
@@ -21,3 +21,11 @@
     padding: 8px 0;
     color: rgba(0, 0, 0, 0.6);
 }
+
+.instanceComponents {
+    margin-bottom: 16px;
+}
+
+.instanceTitle {
+    margin: 8px 0;
+}

--- a/src/views/instances/details/instance-components.tsx
+++ b/src/views/instances/details/instance-components.tsx
@@ -1,62 +1,12 @@
-import { useAlert } from '@dhis2/app-service-alerts'
-import { Button, CircularLoader, DataTable, DataTableBody, DataTableCell, DataTableColumnHeader, DataTableHead, DataTableRow, IconSync16, Tag } from '@dhis2/ui'
-import { Fragment, useCallback, useState } from 'react'
+import { Button, CircularLoader } from '@dhis2/ui'
 import type { FC } from 'react'
-import Moment from 'react-moment'
-import { ConfirmationModal } from '../../../components/index.ts'
 import { useAuthAxios } from '../../../hooks/index.ts'
-import { InstanceComponent, InstanceComponentReplica } from '../../../types/index.ts'
+import { InstanceComponent } from '../../../types/index.ts'
+import { ComponentsTable } from './components-table.tsx'
 import styles from './instance-components.module.css'
-
-const getReplicaTagProps = (replica: InstanceComponentReplica) => {
-    if (replica.phase === 'Failed') {
-        return { negative: true }
-    }
-    if (replica.phase === 'Running' && replica.ready) {
-        return { positive: true }
-    }
-    return { neutral: true }
-}
-
-type RestartTarget = {
-    selector: string
-    replica?: string
-}
-
-const describeTarget = (target: RestartTarget) => (target.replica ? `replica "${target.replica}" of component "${target.selector}"` : `component "${target.selector}"`)
 
 export const InstanceComponents: FC<{ instanceId: number }> = ({ instanceId }) => {
     const [{ data: components, loading, error }, refetch] = useAuthAxios<InstanceComponent[]>({ url: `/instances/${instanceId}/components` }, { useCache: false, autoCatch: true })
-    const [restartTarget, setRestartTarget] = useState<RestartTarget | null>(null)
-
-    const { show: showAlert } = useAlert(
-        ({ message }) => message,
-        ({ isCritical }) => (isCritical ? { critical: true } : { success: true })
-    )
-
-    const [{ loading: restarting }, restart] = useAuthAxios(
-        {
-            method: 'PUT',
-            url: `/instances/${instanceId}/restart`,
-        },
-        { manual: true, autoCancel: false }
-    )
-
-    const onConfirmRestart = useCallback(async () => {
-        const target = restartTarget
-        setRestartTarget(null)
-        if (!target) {
-            return
-        }
-        try {
-            await restart({ params: target })
-            showAlert({ message: `Successfully requested restart of ${describeTarget(target)}`, isCritical: false })
-            refetch()
-        } catch (restartError) {
-            showAlert({ message: `There was an error when restarting ${describeTarget(target)}`, isCritical: true })
-            console.error(restartError)
-        }
-    }, [restartTarget, restart, showAlert, refetch])
 
     /* Instances deployed against a pre-3.0 backend have nothing to show here; hide the section
      * instead of surfacing the error. */
@@ -81,95 +31,13 @@ export const InstanceComponents: FC<{ instanceId: number }> = ({ instanceId }) =
 
     return (
         <>
-            {restartTarget && (
-                <ConfirmationModal onCancel={() => setRestartTarget(null)} onConfirm={onConfirmRestart}>
-                    Are you sure you want to restart {describeTarget(restartTarget)}?
-                </ConfirmationModal>
-            )}
             <div className={styles.header}>
                 <h3>Components</h3>
                 <Button small onClick={() => refetch()} loading={loading} dataTest="refresh-components-button">
                     Refresh
                 </Button>
             </div>
-            <DataTable dataTest="instance-components">
-                <DataTableHead>
-                    <DataTableRow>
-                        <DataTableColumnHeader>Component</DataTableColumnHeader>
-                        <DataTableColumnHeader>Replica</DataTableColumnHeader>
-                        <DataTableColumnHeader>Status</DataTableColumnHeader>
-                        <DataTableColumnHeader>Restarts</DataTableColumnHeader>
-                        <DataTableColumnHeader>Created</DataTableColumnHeader>
-                        <DataTableColumnHeader></DataTableColumnHeader>
-                    </DataTableRow>
-                </DataTableHead>
-                <DataTableBody loading={loading}>
-                    {(components ?? []).map((component) => (
-                        <Fragment key={component.name}>
-                            <DataTableRow>
-                                <DataTableCell staticStyle>{component.name}</DataTableCell>
-                                <DataTableCell></DataTableCell>
-                                <DataTableCell>
-                                    {component.supportedOperations.map((operation) => (
-                                        <Tag key={operation}>{operation}</Tag>
-                                    ))}
-                                </DataTableCell>
-                                <DataTableCell></DataTableCell>
-                                <DataTableCell></DataTableCell>
-                                <DataTableCell>
-                                    {component.supportedOperations.includes('restart') && (
-                                        <Button
-                                            small
-                                            icon={<IconSync16 />}
-                                            disabled={restarting}
-                                            onClick={() => setRestartTarget({ selector: component.name })}
-                                            dataTest={`restart-component-${component.name}`}
-                                        >
-                                            Restart
-                                        </Button>
-                                    )}
-                                </DataTableCell>
-                            </DataTableRow>
-                            {component.replicas.map((replica) => (
-                                <DataTableRow key={replica.name}>
-                                    <DataTableCell></DataTableCell>
-                                    <DataTableCell staticStyle>{replica.name}</DataTableCell>
-                                    <DataTableCell>
-                                        <Tag {...getReplicaTagProps(replica)}>{replica.ready ? replica.phase : `${replica.phase} (not ready)`}</Tag>
-                                    </DataTableCell>
-                                    <DataTableCell>{replica.restarts}</DataTableCell>
-                                    <DataTableCell>
-                                        <Moment date={replica.createdAt} fromNow />
-                                    </DataTableCell>
-                                    <DataTableCell>
-                                        {component.supportedOperations.includes('restartReplica') && (
-                                            <Button
-                                                small
-                                                icon={<IconSync16 />}
-                                                disabled={restarting}
-                                                onClick={() => setRestartTarget({ selector: component.name, replica: replica.name })}
-                                                dataTest={`restart-replica-${replica.name}`}
-                                            >
-                                                Restart replica
-                                            </Button>
-                                        )}
-                                    </DataTableCell>
-                                </DataTableRow>
-                            ))}
-                            {component.replicas.length === 0 && (
-                                <DataTableRow>
-                                    <DataTableCell></DataTableCell>
-                                    <DataTableCell>No replicas</DataTableCell>
-                                    <DataTableCell></DataTableCell>
-                                    <DataTableCell></DataTableCell>
-                                    <DataTableCell></DataTableCell>
-                                    <DataTableCell></DataTableCell>
-                                </DataTableRow>
-                            )}
-                        </Fragment>
-                    ))}
-                </DataTableBody>
-            </DataTable>
+            <ComponentsTable instanceId={instanceId} components={components ?? []} onChanged={refetch} />
         </>
     )
 }

--- a/src/views/instances/list/deployment-component-tags.tsx
+++ b/src/views/instances/list/deployment-component-tags.tsx
@@ -1,0 +1,45 @@
+import { CircularLoader, Tag } from '@dhis2/ui'
+import type { FC } from 'react'
+import { useAuthAxios } from '../../../hooks/index.ts'
+import { DeploymentInstanceComponents, InstanceComponent } from '../../../types/index.ts'
+
+const getComponentTagProps = (component: InstanceComponent) => {
+    if (component.replicas.length === 0) {
+        return { neutral: true }
+    }
+    if (component.replicas.some((replica) => replica.phase === 'Failed')) {
+        return { negative: true }
+    }
+    if (component.replicas.every((replica) => replica.ready)) {
+        return { positive: true }
+    }
+    return { neutral: true }
+}
+
+/* One tag per component currently associated with the deployment, across all its instances,
+ * colored by the state of the component's replicas in the cluster. */
+export const DeploymentComponentTags: FC<{ deploymentId: number }> = ({ deploymentId }) => {
+    const [{ data: instances, loading, error }] = useAuthAxios<DeploymentInstanceComponents[]>(
+        { url: `/deployments/${deploymentId}/components` },
+        { useCache: false, autoCatch: true }
+    )
+
+    if (loading && !instances) {
+        return <CircularLoader extrasmall />
+    }
+    if (error || !instances) {
+        return null
+    }
+
+    return (
+        <>
+            {instances.flatMap((instance) =>
+                instance.components.map((component) => (
+                    <Tag key={`${instance.instanceId}-${component.name}`} {...getComponentTagProps(component)}>
+                        {component.name}
+                    </Tag>
+                ))
+            )}
+        </>
+    )
+}

--- a/src/views/instances/list/instances-list.module.css
+++ b/src/views/instances/list/instances-list.module.css
@@ -42,4 +42,6 @@ td {
     margin-right: 0;
     margin-bottom: 0;
 }
-.expandedComponents { padding: 8px 16px 16px; }
+.expandedComponents {
+    padding: 8px 16px 16px;
+}

--- a/src/views/instances/list/instances-list.tsx
+++ b/src/views/instances/list/instances-list.tsx
@@ -17,8 +17,8 @@ import Moment from 'react-moment'
 import { useNavigate } from 'react-router-dom'
 import { Heading, MomentExpiresFromNow } from '../../../components/index.ts'
 import { DeleteButton } from './delete-menu-button.tsx'
+import { DeploymentComponentTags } from './deployment-component-tags.tsx'
 import useDeployments from './filter-deployments.tsx'
-import InstanceTag from './instance-tag.tsx'
 import styles from './instances-list.module.css'
 import { OpenButton } from './open-button.tsx'
 export const InstancesList: FC = () => {
@@ -74,9 +74,7 @@ export const InstancesList: FC = () => {
                                 >
                                     <DataTableCell>{deployment.name}</DataTableCell>
                                     <DataTableCell>
-                                        {deployment.instances?.map(({ stackName, id }) => (
-                                            <InstanceTag key={stackName} instanceId={id} stackName={stackName} />
-                                        ))}
+                                        <DeploymentComponentTags deploymentId={deployment.id} />
                                     </DataTableCell>
                                     <DataTableCell>
                                         <Moment date={deployment.createdAt} fromNow />


### PR DESCRIPTION
Reshapes the component views per design feedback, driven by the new GET /deployments/:id/components endpoint (companion PR dhis2-sre/im-manager#1638).

The instances list page replaces the single default-pod status tag per instance with one tag per component currently in the cluster for the deployment, across all its instances, colored by replica state and loaded lazily with a spinner.

The deployment details page drops the expandable rows and lists every instance's components inline. Each component row has a dropdown menu offering exactly the operations it advertises: restart and per-replica restart are wired, other capabilities show disabled until they gain actions. The instance details page reuses the same table and menu.

The expandable treatment moves conceptually to the deploy form as conditional parameter groups, which is roadmap step 10.