### PR TITLE
fix: always show the components caption and use the expandable row for parameters

### DIFF
--- a/src/views/instances/details/deployment-components.tsx
+++ b/src/views/instances/details/deployment-components.tsx
@@ -11,21 +11,6 @@ export const DeploymentComponents: FC<{ deploymentId: number }> = ({ deploymentI
         { useCache: false, autoCatch: true }
     )
 
-    if (error) {
-        return null
-    }
-
-    /* The listing queries the cluster for every component of every instance, so it is slow by
-     * nature; show that something is happening rather than nothing. */
-    if (loading && !instances) {
-        return (
-            <div className={styles.loading} data-test="deployment-components-loading">
-                <CircularLoader small />
-                <span>Fetching components from the cluster...</span>
-            </div>
-        )
-    }
-
     return (
         <>
             <div className={styles.header}>
@@ -34,6 +19,15 @@ export const DeploymentComponents: FC<{ deploymentId: number }> = ({ deploymentI
                     Refresh
                 </Button>
             </div>
+            {/* The listing queries the cluster for every component of every instance, so it is slow
+             * by nature; show that something is happening rather than nothing. */}
+            {loading && !instances && (
+                <div className={styles.loading} data-test="deployment-components-loading">
+                    <CircularLoader small />
+                    <span>Fetching components from the cluster...</span>
+                </div>
+            )}
+            {error && !loading && <p className={styles.empty}>Could not load components, is the backend up to date?</p>}
             {(instances ?? []).map((instance) => (
                 <div key={instance.instanceId} className={styles.instanceComponents}>
                     <h4 className={styles.instanceTitle}>

--- a/src/views/instances/details/parameters-section.tsx
+++ b/src/views/instances/details/parameters-section.tsx
@@ -1,4 +1,4 @@
-import { Button, DataTable, DataTableBody, DataTableCell, DataTableColumnHeader, DataTableHead, DataTableRow, IconChevronDown16, IconChevronRight16, IconLock16 } from '@dhis2/ui'
+import { Button, DataTable, DataTableBody, DataTableCell, DataTableColumnHeader, DataTableHead, DataTableRow, IconLock16 } from '@dhis2/ui'
 import { useMemo, useState } from 'react'
 import type { FC } from 'react'
 import { Link } from 'react-router-dom'
@@ -26,49 +26,48 @@ export const ParametersSection: FC<{ instance: DeploymentInstance }> = ({ instan
 
     return (
         <div className={styles.instanceComponents}>
-            <div className={styles.header}>
-                <h3>
-                    Parameters: {instance.name} ({instance.stackName})
-                </h3>
-                <Button
-                    small
-                    icon={expanded ? <IconChevronDown16 /> : <IconChevronRight16 />}
-                    onClick={() => setExpanded((current) => !current)}
-                    dataTest={`toggle-parameters-${instance.id}`}
-                >
-                    {expanded ? 'Hide' : 'Show'}
-                </Button>
-            </div>
-            {expanded && (
-                <DataTable>
-                    <DataTableHead>
-                        <DataTableRow>
-                            <DataTableColumnHeader>Name</DataTableColumnHeader>
-                            <DataTableColumnHeader>Value</DataTableColumnHeader>
-                        </DataTableRow>
-                    </DataTableHead>
-                    <DataTableBody>
-                        {Object.keys(instance.parameters).map((name) => (
-                            <DataTableRow key={name}>
-                                <DataTableCell staticStyle>{name}</DataTableCell>
-                                <DataTableCell staticStyle>
-                                    {stackParameters[name]?.sensitive && (
-                                        <span>
-                                            <Button disabled={true}>
-                                                <IconLock16 />
-                                            </Button>
-                                        </span>
-                                    )}
-                                    {!stackParameters[name]?.sensitive && name === 'DATABASE_ID' && (
-                                        <Link to={`/databases/${instance.parameters[name].value}`}>{instance.parameters[name].value}</Link>
-                                    )}
-                                    {!stackParameters[name]?.sensitive && name !== 'DATABASE_ID' && instance.parameters[name].value}
-                                </DataTableCell>
-                            </DataTableRow>
-                        ))}
-                    </DataTableBody>
-                </DataTable>
-            )}
+            <DataTable dataTest={`parameters-${instance.id}`}>
+                <DataTableBody>
+                    <DataTableRow
+                        expanded={expanded}
+                        onExpandToggle={() => setExpanded((current) => !current)}
+                        expandableContent={
+                            <DataTable>
+                                <DataTableHead>
+                                    <DataTableRow>
+                                        <DataTableColumnHeader>Name</DataTableColumnHeader>
+                                        <DataTableColumnHeader>Value</DataTableColumnHeader>
+                                    </DataTableRow>
+                                </DataTableHead>
+                                <DataTableBody>
+                                    {Object.keys(instance.parameters).map((name) => (
+                                        <DataTableRow key={name}>
+                                            <DataTableCell staticStyle>{name}</DataTableCell>
+                                            <DataTableCell staticStyle>
+                                                {stackParameters[name]?.sensitive && (
+                                                    <span>
+                                                        <Button disabled={true}>
+                                                            <IconLock16 />
+                                                        </Button>
+                                                    </span>
+                                                )}
+                                                {!stackParameters[name]?.sensitive && name === 'DATABASE_ID' && (
+                                                    <Link to={`/databases/${instance.parameters[name].value}`}>{instance.parameters[name].value}</Link>
+                                                )}
+                                                {!stackParameters[name]?.sensitive && name !== 'DATABASE_ID' && instance.parameters[name].value}
+                                            </DataTableCell>
+                                        </DataTableRow>
+                                    ))}
+                                </DataTableBody>
+                            </DataTable>
+                        }
+                    >
+                        <DataTableCell staticStyle>
+                            Parameters: {instance.name} ({instance.stackName})
+                        </DataTableCell>
+                    </DataTableRow>
+                </DataTableBody>
+            </DataTable>
         </div>
     )
 }


### PR DESCRIPTION
The components section now always renders its caption and refresh button. While loading it shows the fetching spinner, and on an error it says the components could not be loaded instead of disappearing silently, which made a stale backend look like a missing feature.

The parameters widget swaps the show/hide button for the DataTable expandable row with the chevron, matching the expandable style used elsewhere.