### PR TITLE
fix: drop the instance captions from the components and parameters widgets

### DIFF
--- a/src/views/instances/details/deployment-components.tsx
+++ b/src/views/instances/details/deployment-components.tsx
@@ -30,9 +30,6 @@ export const DeploymentComponents: FC<{ deploymentId: number }> = ({ deploymentI
             {error && !loading && <p className={styles.empty}>Could not load components, is the backend up to date?</p>}
             {(instances ?? []).map((instance) => (
                 <div key={instance.instanceId} className={styles.instanceComponents}>
-                    <h4 className={styles.instanceTitle}>
-                        {instance.instanceName} ({instance.stackName})
-                    </h4>
                     <ComponentsTable instanceId={instance.instanceId} components={instance.components} onChanged={refetch} />
                 </div>
             ))}

--- a/src/views/instances/details/parameters-section.tsx
+++ b/src/views/instances/details/parameters-section.tsx
@@ -62,9 +62,7 @@ export const ParametersSection: FC<{ instance: DeploymentInstance }> = ({ instan
                             </DataTable>
                         }
                     >
-                        <DataTableCell staticStyle>
-                            Parameters: {instance.name} ({instance.stackName})
-                        </DataTableCell>
+                        <DataTableCell staticStyle>Parameters:</DataTableCell>
                     </DataTableRow>
                 </DataTableBody>
             </DataTable>


### PR DESCRIPTION
The components section no longer repeats the instance name and stack above the table, and the parameters expander row is labeled just Parameters instead of naming the instance.