### PR TITLE
fix: highlight the whole component row on hover

### DIFF
--- a/src/views/instances/details/components-table.tsx
+++ b/src/views/instances/details/components-table.tsx
@@ -36,8 +36,8 @@ export const ComponentsTable: FC<{
                 <Fragment key={component.name}>
                     {component.replicas.map((replica, index) => (
                         <DataTableRow key={replica.name}>
-                            <DataTableCell staticStyle>{index === 0 ? component.name : ''}</DataTableCell>
-                            <DataTableCell staticStyle>{replica.name}</DataTableCell>
+                            <DataTableCell>{index === 0 ? component.name : ''}</DataTableCell>
+                            <DataTableCell>{replica.name}</DataTableCell>
                             <DataTableCell>
                                 <Tag {...getReplicaTagProps(replica)}>{replica.ready ? replica.phase : `${replica.phase} (not ready)`}</Tag>
                             </DataTableCell>
@@ -52,7 +52,7 @@ export const ComponentsTable: FC<{
                     ))}
                     {component.replicas.length === 0 && (
                         <DataTableRow>
-                            <DataTableCell staticStyle>{component.name}</DataTableCell>
+                            <DataTableCell>{component.name}</DataTableCell>
                             <DataTableCell>No replicas</DataTableCell>
                             <DataTableCell></DataTableCell>
                             <DataTableCell></DataTableCell>


### PR DESCRIPTION
The component and replica name cells used staticStyle, which keeps a fixed background and exempts them from the row hover highlight. Removing it makes the whole row highlight on hover.