### PR TITLE
fix: bold the parameters label and drop the colon

### DIFF
--- a/src/views/instances/details/parameters-section.tsx
+++ b/src/views/instances/details/parameters-section.tsx
@@ -62,7 +62,9 @@ export const ParametersSection: FC<{ instance: DeploymentInstance }> = ({ instan
                             </DataTable>
                         }
                     >
-                        <DataTableCell staticStyle>Parameters:</DataTableCell>
+                        <DataTableCell staticStyle>
+                            <strong>Parameters</strong>
+                        </DataTableCell>
                     </DataTableRow>
                 </DataTableBody>
             </DataTable>


### PR DESCRIPTION
The parameters expander row label is now bold and reads Parameters without the trailing colon.