### PR TITLE
feat: move replica restart onto the replica rows

### DIFF
--- a/src/views/instances/details/component-operations-menu.tsx
+++ b/src/views/instances/details/component-operations-menu.tsx
@@ -8,13 +8,13 @@ import { InstanceComponent } from '../../../types/index.ts'
 
 type RestartTarget = {
     selector: string
-    replica?: string
 }
 
-const describeTarget = (target: RestartTarget) => (target.replica ? `replica "${target.replica}" of component "${target.selector}"` : `component "${target.selector}"`)
+const describeTarget = (target: RestartTarget) => `component "${target.selector}"`
 
 /* Operations the menu knows how to perform; every other advertised operation is shown disabled so
- * capabilities stay visible until they get an action here. */
+ * capabilities stay visible until they get an action here. restartReplica is excluded because it
+ * is actioned per replica row, not from this menu. */
 const actionableOperations = ['restart', 'restartReplica']
 
 export const ComponentOperationsMenu: FC<{
@@ -81,15 +81,6 @@ export const ComponentOperationsMenu: FC<{
                 <Popover onClickOutside={() => setOpen(false)} reference={anchor} placement="bottom-start">
                     <Menu>
                         {component.supportedOperations.includes('restart') && <MenuItem dense label="Restart" onClick={() => confirmTarget({ selector: component.name })} />}
-                        {component.supportedOperations.includes('restartReplica') &&
-                            component.replicas.map((replica) => (
-                                <MenuItem
-                                    dense
-                                    key={replica.name}
-                                    label={`Restart replica ${replica.name}`}
-                                    onClick={() => confirmTarget({ selector: component.name, replica: replica.name })}
-                                />
-                            ))}
                         {component.supportedOperations
                             .filter((operation) => !actionableOperations.includes(operation))
                             .map((operation) => (

--- a/src/views/instances/details/components-table.tsx
+++ b/src/views/instances/details/components-table.tsx
@@ -4,6 +4,7 @@ import type { FC } from 'react'
 import Moment from 'react-moment'
 import { InstanceComponent, InstanceComponentReplica } from '../../../types/index.ts'
 import { ComponentOperationsMenu } from './component-operations-menu.tsx'
+import { ReplicaRestartButton } from './replica-restart-button.tsx'
 
 const getReplicaTagProps = (replica: InstanceComponentReplica) => {
     if (replica.phase === 'Failed') {
@@ -29,6 +30,7 @@ export const ComponentsTable: FC<{
                 <DataTableColumnHeader>Restarts</DataTableColumnHeader>
                 <DataTableColumnHeader>Created</DataTableColumnHeader>
                 <DataTableColumnHeader></DataTableColumnHeader>
+                <DataTableColumnHeader></DataTableColumnHeader>
             </DataTableRow>
         </DataTableHead>
         <DataTableBody>
@@ -46,6 +48,11 @@ export const ComponentsTable: FC<{
                                 <Moment date={replica.createdAt} fromNow />
                             </DataTableCell>
                             <DataTableCell align="right">
+                                {component.supportedOperations.includes('restartReplica') && (
+                                    <ReplicaRestartButton instanceId={instanceId} componentName={component.name} replicaName={replica.name} onChanged={onChanged} />
+                                )}
+                            </DataTableCell>
+                            <DataTableCell align="right">
                                 {index === 0 && <ComponentOperationsMenu instanceId={instanceId} component={component} onChanged={onChanged} />}
                             </DataTableCell>
                         </DataTableRow>
@@ -54,6 +61,7 @@ export const ComponentsTable: FC<{
                         <DataTableRow>
                             <DataTableCell>{component.name}</DataTableCell>
                             <DataTableCell>No replicas</DataTableCell>
+                            <DataTableCell></DataTableCell>
                             <DataTableCell></DataTableCell>
                             <DataTableCell></DataTableCell>
                             <DataTableCell></DataTableCell>

--- a/src/views/instances/details/replica-restart-button.tsx
+++ b/src/views/instances/details/replica-restart-button.tsx
@@ -1,0 +1,53 @@
+import { useAlert } from '@dhis2/app-service-alerts'
+import { Button, IconSync16, Tooltip } from '@dhis2/ui'
+import { useCallback, useState } from 'react'
+import type { FC } from 'react'
+import { ConfirmationModal } from '../../../components/index.ts'
+import { useAuthAxios } from '../../../hooks/index.ts'
+
+export const ReplicaRestartButton: FC<{
+    instanceId: number
+    componentName: string
+    replicaName: string
+    onChanged: () => void
+}> = ({ instanceId, componentName, replicaName, onChanged }) => {
+    const [confirming, setConfirming] = useState(false)
+
+    const { show: showAlert } = useAlert(
+        ({ message }) => message,
+        ({ isCritical }) => (isCritical ? { critical: true } : { success: true })
+    )
+
+    const [{ loading: restarting }, restart] = useAuthAxios(
+        {
+            method: 'PUT',
+            url: `/instances/${instanceId}/restart`,
+        },
+        { manual: true, autoCancel: false }
+    )
+
+    const onConfirm = useCallback(async () => {
+        setConfirming(false)
+        try {
+            await restart({ params: { selector: componentName, replica: replicaName } })
+            showAlert({ message: `Successfully requested restart of replica "${replicaName}"`, isCritical: false })
+            onChanged()
+        } catch (restartError) {
+            showAlert({ message: `There was an error when restarting replica "${replicaName}"`, isCritical: true })
+            console.error(restartError)
+        }
+    }, [restart, componentName, replicaName, showAlert, onChanged])
+
+    return (
+        <>
+            {confirming && (
+                <ConfirmationModal onCancel={() => setConfirming(false)} onConfirm={onConfirm}>
+                    Are you sure you want to restart replica &quot;{replicaName}&quot;?
+                </ConfirmationModal>
+            )}
+            <Tooltip content="Restart replica">
+                <Button small secondary loading={restarting} icon={<IconSync16 />} onClick={() => setConfirming(true)} dataTest={`replica-restart-${replicaName}`} />
+            </Tooltip>
+        </>
+    )
+}


### PR DESCRIPTION
Each replica row now has its own restart button acting on exactly the pod the row describes, instead of the component dropdown listing a Restart replica item per pod.

The component dropdown keeps the component-scoped operations: the controller-managed rollout restart and the advertised capabilities.