### PR TITLE
feat: metadata-driven dhis2-v2 deploy form with grouped conditional sections

### DIFF
--- a/src/app/app.tsx
+++ b/src/app/app.tsx
@@ -19,6 +19,7 @@ import {
     GroupsList,
     InstancesList,
     NewDhis2Instance,
+    NewDhis2V2Instance,
     NotFound,
     RequestPasswordReset,
     ResetPassword,
@@ -62,6 +63,7 @@ if (location.hostname === 'play.dhis2.org') {
                         <Route path="/clusters" element={<ClustersList />} />
                         <Route path="/clusters/:id" element={<ClusterDetails />} />
                         <Route path="/instances/new" element={<NewDhis2Instance />} />
+                        <Route path="/instances/new-v2" element={<NewDhis2V2Instance />} />
                         <Route path="/instances/:id/edit" element={<EditDhis2Instance />} />
                         <Route path="/instances/:id/details" element={<DeploymentDetails />} />
                         <Route path="/groups" element={<GroupsList />} />

--- a/src/hooks/use-grouped-stack-parameters.ts
+++ b/src/hooks/use-grouped-stack-parameters.ts
@@ -1,0 +1,52 @@
+import { useMemo } from 'react'
+import { StackParameterGroup, StackParameterWithGroup, StackWithParameterGroups } from '../types/index.ts'
+import { useStack } from './use-stacks.ts'
+
+export type GroupedParameters = {
+    group: StackParameterGroup
+    parameters: StackParameterWithGroup[]
+}
+
+/* Stacks without declared groups render as a single flat section. */
+const FLAT_GROUP: StackParameterGroup = { name: '', title: 'Parameters' }
+
+export const useGroupedStackParameters = (stackName: string) => {
+    const { stack: rawStack, loading, error } = useStack(stackName)
+    const stack = rawStack as StackWithParameterGroups | undefined
+
+    const parameters = useMemo(() => (stack?.parameters ?? []).filter((parameter) => !parameter.consumed).sort((a, b) => (a.priority ?? 0) - (b.priority ?? 0)), [stack])
+
+    const groups = useMemo<GroupedParameters[]>(() => {
+        const declaredGroups = stack?.parameterGroups
+        if (!declaredGroups?.length) {
+            return parameters.length > 0 ? [{ group: FLAT_GROUP, parameters }] : []
+        }
+        return declaredGroups
+            .map((group) => ({ group, parameters: parameters.filter((parameter) => parameter.group === group.name) }))
+            .filter((grouped) => grouped.parameters.length > 0)
+    }, [stack, parameters])
+
+    const initialParameterValues = useMemo(
+        () =>
+            parameters.reduce<Record<string, string>>((initialValues, parameter) => {
+                if (parameter.parameterName && parameter.defaultValue !== undefined) {
+                    initialValues[parameter.parameterName] = parameter.defaultValue
+                }
+                return initialValues
+            }, {}),
+        [parameters]
+    )
+
+    const sensitiveParameters = useMemo(
+        () =>
+            parameters.reduce<Record<string, boolean>>((sensitive, parameter) => {
+                if (parameter.parameterName) {
+                    sensitive[parameter.parameterName] = parameter.sensitive ?? false
+                }
+                return sensitive
+            }, {}),
+        [parameters]
+    )
+
+    return { loading, error, groups, initialParameterValues, sensitiveParameters }
+}

--- a/src/hooks/use-stack-deployment-creation.ts
+++ b/src/hooks/use-stack-deployment-creation.ts
@@ -1,0 +1,53 @@
+import { FORM_ERROR } from 'final-form'
+import type { AnyObject } from 'final-form'
+import { useCallback } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { SaveDeploymentRequest, SaveInstanceRequest } from '../types/index.ts'
+import { useAuthAxios } from './use-auth-axios.ts'
+
+/* Creates a deployment with a single instance of the given stack and deploys it. Only the listed
+ * parameters are sent, so values entered in sections that a visibility condition later hid never
+ * reach the backend. */
+export const useStackDeploymentCreation = (stackName: string, getIncludedParameters: (values: AnyObject) => string[]) => {
+    const navigate = useNavigate()
+    const [, executePost] = useAuthAxios(
+        {
+            url: '/deployments',
+            method: 'POST',
+        },
+        { manual: true }
+    )
+
+    return useCallback(
+        async (values: AnyObject) => {
+            try {
+                const deploymentPayload: SaveDeploymentRequest = {
+                    name: values.name,
+                    group: values.groupName,
+                    description: values.description,
+                    ttl: values.ttl,
+                }
+                const { data: deployment } = await executePost({ data: deploymentPayload })
+
+                const included = new Set(getIncludedParameters(values))
+                const stackValues: AnyObject = values[stackName] ?? {}
+                const parameters = Object.entries(stackValues).reduce<Record<string, { value: string }>>((payload, [parameterName, value]) => {
+                    if (value && included.has(parameterName)) {
+                        payload[parameterName] = { value: String(value) }
+                    }
+                    return payload
+                }, {})
+
+                const instancePayload: SaveInstanceRequest = { stackName, parameters, public: values.public }
+                await executePost({ url: `/deployments/${deployment.id}/instance`, data: instancePayload })
+                await executePost({ url: `/deployments/${deployment.id}/deploy` })
+                navigate(`/instances/${deployment.id}/details`)
+                return undefined
+            } catch (error) {
+                console.error(error)
+                return { [FORM_ERROR]: error instanceof Error ? error.message : 'Could not create the deployment' }
+            }
+        },
+        [executePost, navigate, stackName, getIncludedParameters]
+    )
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,2 +1,3 @@
 export type * from './generated'
 export type * from './instance-components.ts'
+export type * from './stack-parameter-groups.ts'

--- a/src/types/stack-parameter-groups.ts
+++ b/src/types/stack-parameter-groups.ts
@@ -1,0 +1,19 @@
+import { Stack, StackParameter } from './generated/index.ts'
+
+export type StackParameterCondition = {
+    parameter: string
+    equals: string
+}
+
+export type StackParameterGroup = {
+    name: string
+    title: string
+    when?: StackParameterCondition
+}
+
+export type StackParameterWithGroup = StackParameter & { group?: string }
+
+export type StackWithParameterGroups = Omit<Stack, 'parameters'> & {
+    parameterGroups?: StackParameterGroup[]
+    parameters?: StackParameterWithGroup[]
+}

--- a/src/views/instances/details/parameters-section.tsx
+++ b/src/views/instances/details/parameters-section.tsx
@@ -42,7 +42,7 @@ export const ParametersSection: FC<{ instance: DeploymentInstance }> = ({ instan
                                 <DataTableBody>
                                     {Object.keys(instance.parameters).map((name) => (
                                         <DataTableRow key={name}>
-                                            <DataTableCell staticStyle>{name}</DataTableCell>
+                                            <DataTableCell staticStyle>{stackParameters[name]?.displayName || name}</DataTableCell>
                                             <DataTableCell staticStyle>
                                                 {stackParameters[name]?.sensitive && (
                                                     <span>

--- a/src/views/instances/index.ts
+++ b/src/views/instances/index.ts
@@ -1,4 +1,5 @@
 export { DeploymentDetails } from './details/index.ts'
 export { InstancesList } from './list/instances-list.tsx'
 export { NewDhis2Instance } from './new-dhis2/index.ts'
+export { NewDhis2V2Instance } from './new-dhis2-v2/index.ts'
 export { EditDhis2Instance } from './new-dhis2/edit-dhis2-instance.tsx'

--- a/src/views/instances/list/instances-list.tsx
+++ b/src/views/instances/list/instances-list.tsx
@@ -31,6 +31,9 @@ export const InstancesList: FC = () => {
                 <Button icon={<IconAdd24 />} onClick={() => navigate('/instances/new')}>
                     New instance
                 </Button>
+                <Button icon={<IconAdd24 />} onClick={() => navigate('/instances/new-v2')}>
+                    New instance (v2)
+                </Button>
                 <Checkbox checked={showOnlyMyInstances} label="Show only my instances" onChange={() => setShowOnlyMyInstances(!showOnlyMyInstances)} />
             </Heading>
 

--- a/src/views/instances/new-dhis2-v2/group-fieldset.tsx
+++ b/src/views/instances/new-dhis2-v2/group-fieldset.tsx
@@ -1,0 +1,81 @@
+import cx from 'classnames'
+import { getIn } from 'final-form'
+import { useEffect, useState } from 'react'
+import type { FC } from 'react'
+import { useForm } from 'react-final-form'
+import { StackParameterGroup, StackParameterWithGroup } from '../../../types/index.ts'
+import { ParameterField } from '../new-dhis2/fields/parameter-field.tsx'
+import { Dhis2StackName } from '../new-dhis2/parameter-fieldset.tsx'
+import styles from '../new-dhis2/styles.module.css'
+
+/* Parameters shown directly in a group's section; everything else goes under its Advanced
+ * configuration expander. */
+const PRIMARY_PARAMETERS = new Set([
+    'IMAGE_TAG',
+    'IMAGE_REPOSITORY',
+    'DATABASE_ID',
+    'DATABASE_SIZE',
+    'STORAGE_TYPE',
+    'MINIO_STORAGE_SIZE',
+    'FILESYSTEM_VOLUME_SIZE',
+    'S3_BUCKET',
+    'S3_REGION',
+    'S3_IDENTITY',
+    'S3_SECRET',
+])
+
+export const GroupFieldset: FC<{
+    stackId: Dhis2StackName
+    group: StackParameterGroup
+    parameters: StackParameterWithGroup[]
+    sensitiveParameters: Record<string, boolean>
+}> = ({ stackId, group, parameters, sensitiveParameters }) => {
+    const form = useForm()
+    const conditionPath = group.when ? `${stackId}.${group.when.parameter}` : null
+    const [conditionValue, setConditionValue] = useState(() => (conditionPath ? getIn(form.getState().values, conditionPath) : null))
+
+    useEffect(() => {
+        if (!conditionPath) {
+            return
+        }
+        return form.subscribe(
+            ({ values }) => {
+                setConditionValue(getIn(values, conditionPath))
+            },
+            { values: true }
+        )
+    }, [form, conditionPath])
+
+    if (group.when && conditionValue !== group.when.equals) {
+        return null
+    }
+
+    const primary = parameters.filter((parameter) => PRIMARY_PARAMETERS.has(parameter.parameterName ?? ''))
+    const secondary = parameters.filter((parameter) => !PRIMARY_PARAMETERS.has(parameter.parameterName ?? ''))
+
+    const renderField = (parameter: StackParameterWithGroup) => (
+        <ParameterField
+            key={parameter.parameterName}
+            stackId={stackId}
+            parameterName={parameter.parameterName ?? ''}
+            displayName={parameter.displayName ?? parameter.parameterName ?? ''}
+            sensitive={sensitiveParameters[parameter.parameterName ?? '']}
+        />
+    )
+
+    return (
+        <>
+            <fieldset className={cx(styles.fieldset, styles.parameters, styles.primary)}>
+                <legend className={styles.legend}>{group.title}</legend>
+                {primary.map(renderField)}
+                {secondary.length > 0 && (
+                    <details>
+                        <summary className={styles.summary}>Advanced configuration</summary>
+                        <fieldset className={cx(styles.fieldset, styles.parameters, styles.secondary)}>{secondary.map(renderField)}</fieldset>
+                    </details>
+                )}
+            </fieldset>
+            <hr className={styles.hr} />
+        </>
+    )
+}

--- a/src/views/instances/new-dhis2-v2/index.ts
+++ b/src/views/instances/new-dhis2-v2/index.ts
@@ -1,0 +1,1 @@
+export { NewDhis2V2Instance } from './new-dhis2-v2-instance.tsx'

--- a/src/views/instances/new-dhis2-v2/new-dhis2-v2-form.tsx
+++ b/src/views/instances/new-dhis2-v2/new-dhis2-v2-form.tsx
@@ -1,0 +1,83 @@
+import { Button, ButtonStrip, CircularLoader, NoticeBox } from '@dhis2/ui'
+import cx from 'classnames'
+import type { AnyObject } from 'final-form'
+import { useEffect } from 'react'
+import type { FC } from 'react'
+import { useForm, useFormState } from 'react-final-form'
+import { useGroupedStackParameters } from '../../../hooks/use-grouped-stack-parameters.ts'
+import { DescriptionTextarea } from '../new-dhis2/fields/description-textarea.tsx'
+import { GroupSelect } from '../new-dhis2/fields/group-select.tsx'
+import { NameInput } from '../new-dhis2/fields/name-input.tsx'
+import { PublicCheckbox } from '../new-dhis2/fields/public-checkbox.tsx'
+import { TtlSelect } from '../new-dhis2/fields/ttl-select.tsx'
+import styles from '../new-dhis2/styles.module.css'
+import { GroupFieldset } from './group-fieldset.tsx'
+
+export const STACK_ID = 'dhis2-v2'
+
+export const NewDhis2V2Form: FC<{
+    handleCancel: () => void
+    handleSubmit: (event?: Partial<Pick<React.SyntheticEvent, 'preventDefault' | 'stopPropagation'>>) => Promise<AnyObject | undefined> | undefined
+}> = ({ handleCancel, handleSubmit }) => {
+    const { groups, initialParameterValues, sensitiveParameters, loading, error } = useGroupedStackParameters(STACK_ID)
+    const form = useForm()
+    const { submitError, submitting, modifiedSinceLastSubmit, pristine, invalid } = useFormState({
+        subscription: {
+            submitError: true,
+            submitting: true,
+            modifiedSinceLastSubmit: true,
+            pristine: true,
+            invalid: true,
+        },
+    })
+    const shouldDisableSubmit = pristine || submitting || (invalid && !submitError) || (submitError && !modifiedSinceLastSubmit)
+
+    useEffect(() => {
+        const currentValues = form.getState().values
+        form.initialize({
+            ...currentValues,
+            [STACK_ID]: {
+                ...initialParameterValues,
+                ...(currentValues[STACK_ID] ?? {}),
+            },
+        })
+    }, [form, initialParameterValues])
+
+    return (
+        <form onSubmit={handleSubmit}>
+            <fieldset className={cx(styles.fieldset, styles.main)}>
+                <legend className={styles.legend}>Basic information</legend>
+                <NameInput />
+                <DescriptionTextarea />
+                <PublicCheckbox />
+                <TtlSelect />
+                <GroupSelect />
+            </fieldset>
+            <hr className={styles.hr} />
+            {loading && <CircularLoader />}
+            {error && !loading && (
+                <NoticeBox error title="Could not load parameter fields">
+                    {error.message}
+                </NoticeBox>
+            )}
+            {!error &&
+                !loading &&
+                groups.map(({ group, parameters }) => (
+                    <GroupFieldset key={group.name} stackId={STACK_ID} group={group} parameters={parameters} sensitiveParameters={sensitiveParameters} />
+                ))}
+            {submitError && (
+                <NoticeBox className={styles.submitError} error title="There was an error in one of the deployment steps">
+                    {submitError}
+                </NoticeBox>
+            )}
+            <ButtonStrip>
+                <Button primary disabled={shouldDisableSubmit} loading={submitting} type="submit">
+                    Create instance
+                </Button>
+                <Button disabled={submitting} onClick={handleCancel}>
+                    Cancel
+                </Button>
+            </ButtonStrip>
+        </form>
+    )
+}

--- a/src/views/instances/new-dhis2-v2/new-dhis2-v2-instance.tsx
+++ b/src/views/instances/new-dhis2-v2/new-dhis2-v2-instance.tsx
@@ -1,0 +1,41 @@
+import { Card } from '@dhis2/ui'
+import type { AnyObject } from 'final-form'
+import type { FC } from 'react'
+import { useCallback } from 'react'
+import { Form } from 'react-final-form'
+import { useNavigate } from 'react-router-dom'
+import { Heading } from '../../../components/index.ts'
+import { useGroupedStackParameters } from '../../../hooks/use-grouped-stack-parameters.ts'
+import { useStackDeploymentCreation } from '../../../hooks/use-stack-deployment-creation.ts'
+import styles from '../new-dhis2/styles.module.css'
+import { NewDhis2V2Form, STACK_ID } from './new-dhis2-v2-form.tsx'
+
+export const NewDhis2V2Instance: FC = () => {
+    const navigate = useNavigate()
+    const navigateToInstanceList = useCallback(() => {
+        navigate('/instances')
+    }, [navigate])
+
+    const { groups } = useGroupedStackParameters(STACK_ID)
+    const getIncludedParameters = useCallback(
+        (values: AnyObject) => {
+            const stackValues: AnyObject = values[STACK_ID] ?? {}
+            return groups
+                .filter(({ group }) => !group.when || stackValues[group.when.parameter] === group.when.equals)
+                .flatMap(({ parameters }) => parameters.map((parameter) => parameter.parameterName ?? ''))
+        },
+        [groups]
+    )
+    const createDeployment = useStackDeploymentCreation(STACK_ID, getIncludedParameters)
+
+    return (
+        <>
+            <Heading title="Create a new DHIS2 Instance (v2)" />
+            <Card className={styles.container}>
+                <Form onSubmit={createDeployment} keepDirtyOnReinitialize>
+                    {({ handleSubmit }) => <NewDhis2V2Form handleCancel={navigateToInstanceList} handleSubmit={handleSubmit} />}
+                </Form>
+            </Card>
+        </>
+    )
+}

--- a/src/views/instances/new-dhis2/parameter-fieldset.tsx
+++ b/src/views/instances/new-dhis2/parameter-fieldset.tsx
@@ -6,7 +6,7 @@ import { useDhis2StackParameters } from '../../../hooks/index.ts'
 import { ParameterField } from './fields/parameter-field.tsx'
 import styles from './styles.module.css'
 
-export type Dhis2StackName = 'dhis2-core' | 'dhis2-db' | 'pgadmin' | 'minio' | 'chap-core' | 'chap-db' | 'chap-valkey' | 'chap-worker'
+export type Dhis2StackName = 'dhis2-core' | 'dhis2-db' | 'pgadmin' | 'minio' | 'chap-core' | 'chap-db' | 'chap-valkey' | 'chap-worker' | 'dhis2-v2'
 export type Dhis2PrimaryField =
     | 'IMAGE_TAG'
     | 'IMAGE_REPOSITORY'


### PR DESCRIPTION
A new deploy form at /instances/new-v2 renders entirely from stack metadata: one section per parameter group served by the stacks API, each section shown or hidden reactively from its declarative when condition. With dhis2-v2 that means the MinIO, S3 and Filesystem sections appear only when the storage type matches, replacing the only in effect if display name caveats. Parameters from hidden sections are not submitted.

Stacks without declared groups fall back to a single flat section, so the form degrades gracefully until im-manager #1641 is deployed.

The details page now renders parameter display names instead of raw names.