### PR TITLE
fix: nest conditional storage sections under dhis2 core and space the advanced expander

### DIFF
--- a/src/views/instances/new-dhis2-v2/group-fieldset.module.css
+++ b/src/views/instances/new-dhis2-v2/group-fieldset.module.css
@@ -1,0 +1,7 @@
+.advanced {
+    margin-top: 16px;
+}
+
+.subGroups {
+    margin-top: 16px;
+}

--- a/src/views/instances/new-dhis2-v2/group-fieldset.tsx
+++ b/src/views/instances/new-dhis2-v2/group-fieldset.tsx
@@ -3,10 +3,12 @@ import { getIn } from 'final-form'
 import { useEffect, useState } from 'react'
 import type { FC } from 'react'
 import { useForm } from 'react-final-form'
+import type { GroupedParameters } from '../../../hooks/use-grouped-stack-parameters.ts'
 import { StackParameterGroup, StackParameterWithGroup } from '../../../types/index.ts'
 import { ParameterField } from '../new-dhis2/fields/parameter-field.tsx'
 import { Dhis2StackName } from '../new-dhis2/parameter-fieldset.tsx'
 import styles from '../new-dhis2/styles.module.css'
+import ownStyles from './group-fieldset.module.css'
 
 /* Parameters shown directly in a group's section; everything else goes under its Advanced
  * configuration expander. */
@@ -15,7 +17,6 @@ const PRIMARY_PARAMETERS = new Set([
     'IMAGE_REPOSITORY',
     'DATABASE_ID',
     'DATABASE_SIZE',
-    'STORAGE_TYPE',
     'MINIO_STORAGE_SIZE',
     'FILESYSTEM_VOLUME_SIZE',
     'S3_BUCKET',
@@ -24,20 +25,16 @@ const PRIMARY_PARAMETERS = new Set([
     'S3_SECRET',
 ])
 
-export const GroupFieldset: FC<{
+const ConditionalSection: FC<{
     stackId: Dhis2StackName
-    group: StackParameterGroup
-    parameters: StackParameterWithGroup[]
-    sensitiveParameters: Record<string, boolean>
-}> = ({ stackId, group, parameters, sensitiveParameters }) => {
+    when: NonNullable<StackParameterGroup['when']>
+    children: React.ReactNode
+}> = ({ stackId, when, children }) => {
     const form = useForm()
-    const conditionPath = group.when ? `${stackId}.${group.when.parameter}` : null
-    const [conditionValue, setConditionValue] = useState(() => (conditionPath ? getIn(form.getState().values, conditionPath) : null))
+    const conditionPath = `${stackId}.${when.parameter}`
+    const [conditionValue, setConditionValue] = useState(() => getIn(form.getState().values, conditionPath))
 
     useEffect(() => {
-        if (!conditionPath) {
-            return
-        }
         return form.subscribe(
             ({ values }) => {
                 setConditionValue(getIn(values, conditionPath))
@@ -46,10 +43,19 @@ export const GroupFieldset: FC<{
         )
     }, [form, conditionPath])
 
-    if (group.when && conditionValue !== group.when.equals) {
+    if (conditionValue !== when.equals) {
         return null
     }
+    return <>{children}</>
+}
 
+export const GroupFieldset: FC<{
+    stackId: Dhis2StackName
+    group: StackParameterGroup
+    parameters: StackParameterWithGroup[]
+    subGroups?: GroupedParameters[]
+    sensitiveParameters: Record<string, boolean>
+}> = ({ stackId, group, parameters, subGroups = [], sensitiveParameters }) => {
     const primary = parameters.filter((parameter) => PRIMARY_PARAMETERS.has(parameter.parameterName ?? ''))
     const secondary = parameters.filter((parameter) => !PRIMARY_PARAMETERS.has(parameter.parameterName ?? ''))
 
@@ -63,18 +69,42 @@ export const GroupFieldset: FC<{
         />
     )
 
+    const body = (
+        <fieldset className={cx(styles.fieldset, styles.parameters, styles.primary)}>
+            <legend className={styles.legend}>{group.title}</legend>
+            {primary.map(renderField)}
+            {secondary.length > 0 && (
+                <details className={ownStyles.advanced}>
+                    <summary className={styles.summary}>Advanced configuration</summary>
+                    <fieldset className={cx(styles.fieldset, styles.parameters, styles.secondary)}>{secondary.map(renderField)}</fieldset>
+                </details>
+            )}
+            {subGroups.length > 0 && (
+                <div className={ownStyles.subGroups}>
+                    {subGroups.map((subGroup) => (
+                        <GroupFieldset
+                            key={subGroup.group.name}
+                            stackId={stackId}
+                            group={subGroup.group}
+                            parameters={subGroup.parameters}
+                            sensitiveParameters={sensitiveParameters}
+                        />
+                    ))}
+                </div>
+            )}
+        </fieldset>
+    )
+
+    if (group.when) {
+        return (
+            <ConditionalSection stackId={stackId} when={group.when}>
+                {body}
+            </ConditionalSection>
+        )
+    }
     return (
         <>
-            <fieldset className={cx(styles.fieldset, styles.parameters, styles.primary)}>
-                <legend className={styles.legend}>{group.title}</legend>
-                {primary.map(renderField)}
-                {secondary.length > 0 && (
-                    <details>
-                        <summary className={styles.summary}>Advanced configuration</summary>
-                        <fieldset className={cx(styles.fieldset, styles.parameters, styles.secondary)}>{secondary.map(renderField)}</fieldset>
-                    </details>
-                )}
-            </fieldset>
+            {body}
             <hr className={styles.hr} />
         </>
     )

--- a/src/views/instances/new-dhis2-v2/new-dhis2-v2-form.tsx
+++ b/src/views/instances/new-dhis2-v2/new-dhis2-v2-form.tsx
@@ -1,10 +1,11 @@
 import { Button, ButtonStrip, CircularLoader, NoticeBox } from '@dhis2/ui'
 import cx from 'classnames'
 import type { AnyObject } from 'final-form'
-import { useEffect } from 'react'
+import { useEffect, useMemo } from 'react'
 import type { FC } from 'react'
 import { useForm, useFormState } from 'react-final-form'
 import { useGroupedStackParameters } from '../../../hooks/use-grouped-stack-parameters.ts'
+import type { GroupedParameters } from '../../../hooks/use-grouped-stack-parameters.ts'
 import { DescriptionTextarea } from '../new-dhis2/fields/description-textarea.tsx'
 import { GroupSelect } from '../new-dhis2/fields/group-select.tsx'
 import { NameInput } from '../new-dhis2/fields/name-input.tsx'
@@ -31,6 +32,23 @@ export const NewDhis2V2Form: FC<{
         },
     })
     const shouldDisableSubmit = pristine || submitting || (invalid && !submitError) || (submitError && !modifiedSinceLastSubmit)
+
+    /* A conditional group nests under the group that owns its enabling parameter, e.g. the MinIO
+     * section renders inside DHIS 2 Core because STORAGE_TYPE lives there. */
+    const { topLevel, subGroupsByParent } = useMemo(() => {
+        const ownerOf = (parameterName: string) => groups.find(({ parameters }) => parameters.some((parameter) => parameter.parameterName === parameterName))
+        const subGroupsByParent = new Map<string, GroupedParameters[]>()
+        const topLevel: GroupedParameters[] = []
+        for (const grouped of groups) {
+            const owner = grouped.group.when ? ownerOf(grouped.group.when.parameter) : undefined
+            if (owner && owner.group.name !== grouped.group.name) {
+                subGroupsByParent.set(owner.group.name, [...(subGroupsByParent.get(owner.group.name) ?? []), grouped])
+            } else {
+                topLevel.push(grouped)
+            }
+        }
+        return { topLevel, subGroupsByParent }
+    }, [groups])
 
     useEffect(() => {
         const currentValues = form.getState().values
@@ -62,8 +80,15 @@ export const NewDhis2V2Form: FC<{
             )}
             {!error &&
                 !loading &&
-                groups.map(({ group, parameters }) => (
-                    <GroupFieldset key={group.name} stackId={STACK_ID} group={group} parameters={parameters} sensitiveParameters={sensitiveParameters} />
+                topLevel.map(({ group, parameters }) => (
+                    <GroupFieldset
+                        key={group.name}
+                        stackId={STACK_ID}
+                        group={group}
+                        parameters={parameters}
+                        subGroups={subGroupsByParent.get(group.name)}
+                        sensitiveParameters={sensitiveParameters}
+                    />
                 ))}
             {submitError && (
                 <NoticeBox className={styles.submitError} error title="There was an error in one of the deployment steps">


### PR DESCRIPTION
A conditional group now renders inside the group that owns its enabling parameter, so with im-manager #1643 the MinIO, S3 and Filesystem sections appear under DHIS 2 Core instead of at top level. STORAGE_TYPE leaves the primary set and renders under advanced configuration.

The Advanced configuration expander gets a margin so it no longer sits flush against the fields above it.