### PR TITLE
fix: span the advanced expander across the parameter grid

### DIFF
--- a/src/views/instances/new-dhis2-v2/group-fieldset.module.css
+++ b/src/views/instances/new-dhis2-v2/group-fieldset.module.css
@@ -1,7 +1,8 @@
 .advanced {
-    margin-top: 16px;
+    grid-column: 1 / -1;
 }
 
 .subGroups {
-    margin-top: 16px;
+    grid-column: 1 / -1;
+    margin-top: var(--spacers-dp16);
 }


### PR DESCRIPTION
The primary parameters fieldset is a three column grid and the Advanced configuration expander rendered as a grid item on the same row as the fields. It now spans the full width, as does the nested sub-group container.