### PR TITLE
feat: optional pgadmin companion on the dhis2-v2 deploy form

### DIFF
--- a/src/hooks/use-stack-deployment-creation.ts
+++ b/src/hooks/use-stack-deployment-creation.ts
@@ -5,10 +5,11 @@ import { useNavigate } from 'react-router-dom'
 import { SaveDeploymentRequest, SaveInstanceRequest } from '../types/index.ts'
 import { useAuthAxios } from './use-auth-axios.ts'
 
-/* Creates a deployment with a single instance of the given stack and deploys it. Only the listed
- * parameters are sent, so values entered in sections that a visibility condition later hid never
- * reach the backend. */
-export const useStackDeploymentCreation = (stackName: string, getIncludedParameters: (values: AnyObject) => string[]) => {
+/* Creates a deployment with an instance of the given stack plus any opted-in companion stacks and
+ * deploys it. Only the listed parameters are sent for the main stack, so values entered in sections
+ * that a visibility condition later hid never reach the backend. A companion is included when the
+ * form's include_<stack> checkbox is set; confirm-password helper fields are never sent. */
+export const useStackDeploymentCreation = (stackName: string, getIncludedParameters: (values: AnyObject) => string[], companionStacks: string[] = []) => {
     const navigate = useNavigate()
     const [, executePost] = useAuthAxios(
         {
@@ -40,6 +41,22 @@ export const useStackDeploymentCreation = (stackName: string, getIncludedParamet
 
                 const instancePayload: SaveInstanceRequest = { stackName, parameters, public: values.public }
                 await executePost({ url: `/deployments/${deployment.id}/instance`, data: instancePayload })
+
+                for (const companion of companionStacks) {
+                    if (!values[`include_${companion}`]) {
+                        continue
+                    }
+                    const companionValues: AnyObject = values[companion] ?? {}
+                    const companionParameters = Object.entries(companionValues).reduce<Record<string, { value: string }>>((payload, [parameterName, value]) => {
+                        if (value && !parameterName.endsWith('CONFIRM_PASSWORD')) {
+                            payload[parameterName] = { value: String(value) }
+                        }
+                        return payload
+                    }, {})
+                    const companionPayload: SaveInstanceRequest = { stackName: companion, parameters: companionParameters }
+                    await executePost({ url: `/deployments/${deployment.id}/instance`, data: companionPayload })
+                }
+
                 await executePost({ url: `/deployments/${deployment.id}/deploy` })
                 navigate(`/instances/${deployment.id}/details`)
                 return undefined
@@ -48,6 +65,6 @@ export const useStackDeploymentCreation = (stackName: string, getIncludedParamet
                 return { [FORM_ERROR]: error instanceof Error ? error.message : 'Could not create the deployment' }
             }
         },
-        [executePost, navigate, stackName, getIncludedParameters]
+        [executePost, navigate, stackName, getIncludedParameters, companionStacks]
     )
 }

--- a/src/views/instances/new-dhis2-v2/new-dhis2-v2-form.tsx
+++ b/src/views/instances/new-dhis2-v2/new-dhis2-v2-form.tsx
@@ -11,6 +11,7 @@ import { GroupSelect } from '../new-dhis2/fields/group-select.tsx'
 import { NameInput } from '../new-dhis2/fields/name-input.tsx'
 import { PublicCheckbox } from '../new-dhis2/fields/public-checkbox.tsx'
 import { TtlSelect } from '../new-dhis2/fields/ttl-select.tsx'
+import { ParameterFieldset } from '../new-dhis2/parameter-fieldset.tsx'
 import styles from '../new-dhis2/styles.module.css'
 import { GroupFieldset } from './group-fieldset.tsx'
 
@@ -90,6 +91,7 @@ export const NewDhis2V2Form: FC<{
                         sensitiveParameters={sensitiveParameters}
                     />
                 ))}
+            {!error && !loading && <ParameterFieldset stackId="pgadmin" displayName="PgAdmin" optional />}
             {submitError && (
                 <NoticeBox className={styles.submitError} error title="There was an error in one of the deployment steps">
                     {submitError}

--- a/src/views/instances/new-dhis2-v2/new-dhis2-v2-instance.tsx
+++ b/src/views/instances/new-dhis2-v2/new-dhis2-v2-instance.tsx
@@ -10,6 +10,8 @@ import { useStackDeploymentCreation } from '../../../hooks/use-stack-deployment-
 import styles from '../new-dhis2/styles.module.css'
 import { NewDhis2V2Form, STACK_ID } from './new-dhis2-v2-form.tsx'
 
+const COMPANION_STACKS = ['pgadmin']
+
 export const NewDhis2V2Instance: FC = () => {
     const navigate = useNavigate()
     const navigateToInstanceList = useCallback(() => {
@@ -26,7 +28,7 @@ export const NewDhis2V2Instance: FC = () => {
         },
         [groups]
     )
-    const createDeployment = useStackDeploymentCreation(STACK_ID, getIncludedParameters)
+    const createDeployment = useStackDeploymentCreation(STACK_ID, getIncludedParameters, COMPANION_STACKS)
 
     return (
         <>


### PR DESCRIPTION
The v2 form gains the old form top-level optional PgAdmin section, reusing the checkbox-gated ParameterFieldset. When included, submission adds a pgadmin instance to the deployment next to the dhis2-v2 instance before deploying.

Requires the provider-based requirement resolution on the backend, without it the pgadmin instance is rejected for missing its required dhis2-db stack.