### PR TITLE
ci: deploy to the im-vm control plane

### DIFF
--- a/.github/workflows/delete-env.yaml
+++ b/.github/workflows/delete-env.yaml
@@ -2,7 +2,7 @@ name: Delete deployed environment
 
 on:
     pull_request:
-        types: [closed]
+        types: [closed, unlabeled]
 
 # Cancel previous runs of the same workflow and PR number or branch/tag
 concurrency:
@@ -16,3 +16,26 @@ jobs:
             AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
             AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
             KUBECONFIG: ${{ secrets.KUBECONFIG }}
+
+    # The same teardown on the Hetzner control plane. Separate from the EKS one above because it is
+    # a different system with a different credential, and it runs whether or not that one did: a
+    # feature environment left behind holds a database, a Redis and a RabbitMQ on a shared box.
+    delete-im-vm-environment:
+        name: Delete the im-vm feature environment
+        runs-on: ubuntu-24.04
+        steps:
+            - name: Destroy
+              env:
+                  DEPLOY_KEY: ${{ secrets.IM_VM_DEV_DEPLOY_KEY }}
+                  HOST: ${{ secrets.IM_VM_DEV_HOST }}
+                  PULL_REQUEST: ${{ github.event.pull_request.number }}
+              run: |
+                  set -o errexit -o nounset -o pipefail
+                  install --mode=600 /dev/null deploy-key
+                  printf '%s\n' "$DEPLOY_KEY" > deploy-key
+                  ssh -i deploy-key -o StrictHostKeyChecking=accept-new -o BatchMode=yes \
+                    im@"$HOST" "down feat-web-$PULL_REQUEST"
+
+            - name: Forget the key
+              if: always()
+              run: rm --force deploy-key

--- a/.github/workflows/deploy-im-vm.yaml
+++ b/.github/workflows/deploy-im-vm.yaml
@@ -1,0 +1,96 @@
+name: Deploy to im-vm
+
+# The Hetzner control plane in dhis2-sre/dhis2-infrastructure services/im-vm, which replaces the EKS
+# instance-cluster. Runs after Build, test and deploy has pushed the image, because it deploys a tag
+# that has to exist, and works out that tag exactly as the build does: the sanitized head branch for
+# a pull request, latest for master, the tag itself for a release. The tag is passed in the web
+# client's position, with - for the manager, so deploying this repository never moves the other's
+# image.
+#
+# The whole interface is a forced command over SSH. A deploy key can start an environment and, for
+# feature environments only, destroy one. It cannot open a shell, and it cannot stop or destroy a
+# long lived environment.
+#
+# Secrets, one pair per server, because the prod key must not be reachable by anything a pull
+# request can trigger:
+#
+#   IM_VM_PROD_HOST, IM_VM_PROD_DEPLOY_KEY   releases
+#   IM_VM_DEV_HOST, IM_VM_DEV_DEPLOY_KEY     master and pull requests
+
+on:
+  workflow_run:
+    workflows: [Build, test and deploy]
+    types: [completed]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Deploy
+    if: github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Work out what to deploy, where
+        id: target
+        env:
+          EVENT: ${{ github.event.workflow_run.event }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          PULL_REQUESTS: ${{ toJSON(github.event.workflow_run.pull_requests) }}
+        run: |
+          set -o errexit -o nounset -o pipefail
+
+          pull_request=$(printf '%s' "$PULL_REQUESTS" | jq -r '.[0].number // empty')
+
+          if [ -n "$pull_request" ]; then
+            # The same sanitisation the build uses for the image tag: lowercase, non-alphanumerics
+            # to hyphens, 25 characters, no trailing hyphen.
+            lowercase=$(printf '%s' "$HEAD_BRANCH" | tr '[:upper:]' '[:lower:]')
+            tag=${lowercase//[^[:alnum:]]/-}
+            tag=${tag::25}
+            tag=${tag%-}
+            echo "server=dev" >> "$GITHUB_OUTPUT"
+            echo "environment=feat-web-$pull_request" >> "$GITHUB_OUTPUT"
+            echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          elif [ "$HEAD_BRANCH" = master ]; then
+            echo "server=dev" >> "$GITHUB_OUTPUT"
+            echo "environment=dev" >> "$GITHUB_OUTPUT"
+            echo "tag=latest" >> "$GITHUB_OUTPUT"
+          else
+            # A release: the build pushes the tag with any v prefix stripped.
+            echo "server=prod" >> "$GITHUB_OUTPUT"
+            echo "environment=prod" >> "$GITHUB_OUTPUT"
+            echo "tag=${HEAD_BRANCH#v}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Deploy to the dev and feature server
+        if: steps.target.outputs.server == 'dev'
+        env:
+          DEPLOY_KEY: ${{ secrets.IM_VM_DEV_DEPLOY_KEY }}
+          HOST: ${{ secrets.IM_VM_DEV_HOST }}
+          ENVIRONMENT: ${{ steps.target.outputs.environment }}
+          TAG: ${{ steps.target.outputs.tag }}
+        run: |
+          set -o errexit -o nounset -o pipefail
+          install --mode=600 /dev/null deploy-key
+          printf '%s\n' "$DEPLOY_KEY" > deploy-key
+          ssh -i deploy-key -o StrictHostKeyChecking=accept-new -o BatchMode=yes \
+            im@"$HOST" "up $ENVIRONMENT - $TAG"
+
+      - name: Deploy to the prod server
+        if: steps.target.outputs.server == 'prod'
+        env:
+          DEPLOY_KEY: ${{ secrets.IM_VM_PROD_DEPLOY_KEY }}
+          HOST: ${{ secrets.IM_VM_PROD_HOST }}
+          TAG: ${{ steps.target.outputs.tag }}
+        run: |
+          set -o errexit -o nounset -o pipefail
+          install --mode=600 /dev/null deploy-key
+          printf '%s\n' "$DEPLOY_KEY" > deploy-key
+          ssh -i deploy-key -o StrictHostKeyChecking=accept-new -o BatchMode=yes \
+            im@"$HOST" "up prod - $TAG"
+
+      - name: Forget the key
+        if: always()
+        run: rm --force deploy-key


### PR DESCRIPTION
Deploys this repository to the Hetzner control plane that replaces the EKS `instance-cluster`, added in dhis2-sre/dhis2-infrastructure#284. Nothing here changes the existing EKS deployment: both run side by side until that migration cuts over, so this is additive and safe to merge before it.

A release tag deploys prod, a push to master deploys dev, and a pull request carrying the `deploy` label gets a feature environment that is destroyed when the label is removed or the pull request closes. The deploy runs on `workflow_run` after `Build, test and deploy` succeeds, because it asks the server for a tag that has to exist already, and it derives that tag exactly as the build does: the sanitized head branch for a pull request, `latest` for master, the tag with any `v` stripped for a release.

The whole interface is a forced command over SSH, so the deploy key can start an environment and, for feature environments only, destroy one. It cannot open a shell, and it cannot stop or destroy a long lived environment: the worst a stolen key does is redeploy at a tag that already exists. Feature environments are named `feat-<repository>-<pull request>` because the two repositories number pull requests independently and a bare number would eventually have two open pull requests claiming the same environment.

Needs four secrets before it can work, and the workflow is a no-op failure until they exist: `IM_VM_PROD_HOST` and `IM_VM_PROD_DEPLOY_KEY`, `IM_VM_DEV_HOST` and `IM_VM_DEV_DEPLOY_KEY`. Two keys rather than one because anything a pull request can trigger must not be able to reach prod. Generate them as described in `services/im-vm/ssh-keys/continuous-integration/README.md` in the infrastructure repository, commit the public halves there, and put the private halves here.

`StrictHostKeyChecking=accept-new` rather than a pinned host key, deliberately: the servers are still being rebuilt during the migration, so a pinned key would break every deploy on each rebuild. Pinning is worth revisiting once they stop moving. A MITM there could fail or fake a deploy but cannot obtain the key, since SSH never sends it.
