### PR TITLE
feat: save database as from the component dropdown

### DIFF
--- a/src/views/instances/details/component-operations-menu.tsx
+++ b/src/views/instances/details/component-operations-menu.tsx
@@ -4,19 +4,22 @@ import { useCallback, useRef, useState } from 'react'
 import type { FC } from 'react'
 import { useAuthAxios } from '../../../hooks/index.ts'
 import { InstanceComponent } from '../../../types/index.ts'
+import { SaveAsModal } from './save-as-modal.tsx'
 
 /* Operations the menu knows how to perform; every other advertised operation is shown disabled so
  * capabilities stay visible until they get an action here. restartReplica is deliberately not
  * surfaced in the UI, the API keeps it for scripting. */
-const handledOperations = ['restart', 'restartReplica']
+const handledOperations = ['restart', 'restartReplica', 'databaseSave']
 
 export const ComponentOperationsMenu: FC<{
     instanceId: number
+    stackName: string
     component: InstanceComponent
     onChanged: () => void
-}> = ({ instanceId, component, onChanged }) => {
+}> = ({ instanceId, stackName, component, onChanged }) => {
     const anchor = useRef<HTMLSpanElement>(null)
     const [open, setOpen] = useState(false)
+    const [showSaveAs, setShowSaveAs] = useState(false)
 
     const { show: showAlert } = useAlert(
         ({ message }) => message,
@@ -45,6 +48,7 @@ export const ComponentOperationsMenu: FC<{
 
     return (
         <>
+            {showSaveAs && <SaveAsModal onClose={() => setShowSaveAs(false)} instanceId={instanceId} stackName={stackName} onStart={() => {}} onComplete={() => {}} />}
             <span ref={anchor}>
                 <Button
                     small
@@ -59,6 +63,16 @@ export const ComponentOperationsMenu: FC<{
                 <Popover onClickOutside={() => setOpen(false)} reference={anchor} placement="bottom-start">
                     <Menu>
                         {component.supportedOperations.includes('restart') && <MenuItem dense label="Restart" onClick={onRestart} />}
+                        {component.supportedOperations.includes('databaseSave') && (
+                            <MenuItem
+                                dense
+                                label="Save database as"
+                                onClick={() => {
+                                    setOpen(false)
+                                    setShowSaveAs(true)
+                                }}
+                            />
+                        )}
                         {component.supportedOperations
                             .filter((operation) => !handledOperations.includes(operation))
                             .map((operation) => (

--- a/src/views/instances/details/components-table.tsx
+++ b/src/views/instances/details/components-table.tsx
@@ -17,9 +17,10 @@ const getReplicaTagProps = (replica: InstanceComponentReplica) => {
 
 export const ComponentsTable: FC<{
     instanceId: number
+    stackName: string
     components: InstanceComponent[]
     onChanged: () => void
-}> = ({ instanceId, components, onChanged }) => (
+}> = ({ instanceId, stackName, components, onChanged }) => (
     <DataTable dataTest="instance-components">
         <DataTableHead>
             <DataTableRow>
@@ -46,7 +47,7 @@ export const ComponentsTable: FC<{
                                 <Moment date={replica.createdAt} fromNow />
                             </DataTableCell>
                             <DataTableCell align="right">
-                                {index === 0 && <ComponentOperationsMenu instanceId={instanceId} component={component} onChanged={onChanged} />}
+                                {index === 0 && <ComponentOperationsMenu instanceId={instanceId} stackName={stackName} component={component} onChanged={onChanged} />}
                             </DataTableCell>
                         </DataTableRow>
                     ))}
@@ -58,7 +59,7 @@ export const ComponentsTable: FC<{
                             <DataTableCell></DataTableCell>
                             <DataTableCell></DataTableCell>
                             <DataTableCell align="right">
-                                <ComponentOperationsMenu instanceId={instanceId} component={component} onChanged={onChanged} />
+                                <ComponentOperationsMenu instanceId={instanceId} stackName={stackName} component={component} onChanged={onChanged} />
                             </DataTableCell>
                         </DataTableRow>
                     )}

--- a/src/views/instances/details/deployment-components.tsx
+++ b/src/views/instances/details/deployment-components.tsx
@@ -30,7 +30,7 @@ export const DeploymentComponents: FC<{ deploymentId: number }> = ({ deploymentI
             {error && !loading && <p className={styles.empty}>Could not load components, is the backend up to date?</p>}
             {(instances ?? []).map((instance) => (
                 <div key={instance.instanceId} className={styles.instanceComponents}>
-                    <ComponentsTable instanceId={instance.instanceId} components={instance.components} onChanged={refetch} />
+                    <ComponentsTable instanceId={instance.instanceId} stackName={instance.stackName} components={instance.components} onChanged={refetch} />
                 </div>
             ))}
         </>


### PR DESCRIPTION
Components advertising the databaseSave capability get a Save database as item in their dropdown, opening the existing save-as modal against the owning instance. Until the backend serves the capability the menu is unchanged, so this deploys safely ahead of im-manager #1647 and #1648.