### PR TITLE
fix: deploy an im-vm feature environment only for a labelled pull request

### DIFF
--- a/.github/workflows/delete-env.yaml
+++ b/.github/workflows/delete-env.yaml
@@ -23,6 +23,9 @@ jobs:
     delete-im-vm-environment:
         name: Delete the im-vm feature environment
         runs-on: ubuntu-24.04
+        # A closed pull request has no environment either way, but unlabeled fires for every label,
+        # and only this one created anything.
+        if: github.event.action == 'closed' || github.event.label.name == 'deploy'
         steps:
             - name: Destroy
               env:

--- a/.github/workflows/deploy-im-vm.yaml
+++ b/.github/workflows/deploy-im-vm.yaml
@@ -5,7 +5,8 @@ name: Deploy to im-vm
 # that has to exist, and works out that tag exactly as the build does: the sanitized head branch for
 # a pull request, latest for master, the tag itself for a release. The tag is passed in the web
 # client's position, with - for the manager, so deploying this repository never moves the other's
-# image.
+# image. A pull request gets an environment only while it carries the deploy label, which is the
+# label the EKS deploy uses too.
 #
 # The whole interface is a forced command over SSH. A deploy key can start an environment and, for
 # feature environments only, destroy one. It cannot open a shell, and it cannot stop or destroy a
@@ -38,12 +39,26 @@ jobs:
           EVENT: ${{ github.event.workflow_run.event }}
           HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
           PULL_REQUESTS: ${{ toJSON(github.event.workflow_run.pull_requests) }}
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
         run: |
           set -o errexit -o nounset -o pipefail
 
           pull_request=$(printf '%s' "$PULL_REQUESTS" | jq -r '.[0].number // empty')
 
           if [ -n "$pull_request" ]; then
+            # Opt in per pull request, on the same label the EKS deploy in gha-workflows uses, so
+            # one label drives both and removing it tears both down. An environment costs a
+            # database, a Redis and a RabbitMQ on a box shared with dev, and the build runs on
+            # every pull request event, so without this every open pull request would claim one.
+            labelled=$(gh pr view "$pull_request" --repo "$REPOSITORY" --json labels \
+              --jq 'any(.labels[].name; . == "deploy")')
+            if [ "$labelled" != true ]; then
+              echo "pull request $pull_request is not labelled deploy, nothing to deploy"
+              echo "server=none" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+
             # The same sanitisation the build uses for the image tag: lowercase, non-alphanumerics
             # to hyphens, 25 characters, no trailing hyphen.
             lowercase=$(printf '%s' "$HEAD_BRANCH" | tr '[:upper:]' '[:lower:]')


### PR DESCRIPTION
`Build, test and deploy` runs on every pull request event, so `Deploy to im-vm` as merged creates a `feat-web-<pull request>` environment for every open pull request, and a server admits four of them. This gates it on the `deploy` label, the one the EKS deploy in gha-workflows already keys off, so a single label drives both systems.

The teardown is gated the same way: `unlabeled` fires for every label, and only `deploy` created anything.

Companion to dhis2-sre/im-manager#1655 and dhis2-sre/dhis2-infrastructure#284.