### PR TITLE
fix: bump react to 19.2.8 to match react-dom

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
         "moment": "^2.30.1",
         "pretty-bytes": "^7.1.0",
         "prop-types": "^15.8.1",
-        "react": "^19.2.7",
+        "react": "^19.2.8",
         "react-dom": "^19.2.8",
         "react-final-form": "^7.0.1",
         "react-moment": "^1.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7098,7 +7098,7 @@ __metadata:
     prettier: "npm:^3.8.3"
     pretty-bytes: "npm:^7.1.0"
     prop-types: "npm:^15.8.1"
-    react: "npm:^19.2.7"
+    react: "npm:^19.2.8"
     react-dom: "npm:^19.2.8"
     react-final-form: "npm:^7.0.1"
     react-moment: "npm:^1.1.3"
@@ -9248,10 +9248,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react@npm:^19.2.7":
-  version: 19.2.7
-  resolution: "react@npm:19.2.7"
-  checksum: 10c0/0bd0e2f1bbd4ba97561c6597bf8a5fec05e6476fe61e165c1065598d16668efc6715205599c94d3ddd49d36cb0f21cbf1b9bcc18ee840b805ce222c3e8d558ac
+"react@npm:^19.2.8":
+  version: 19.2.8
+  resolution: "react@npm:19.2.8"
+  checksum: 10c0/5f86bdb56426652fd6d989d30a6f2e603c057272c47c9ca3a3fbe190a3a39ee9ccce937d63cfc039717abed1b8891d6a499134bc35311acc07eafdacd86537cd
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
#871 bumped `react-dom` to 19.2.8 without bumping `react`, which stayed at 19.2.7. React verifies at runtime that both packages have the same version, so im-dev fails to load with minified React error #527. This bumps `react` to 19.2.8 to match.