### PR TITLE
ci: group react updates in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,10 @@ updates:
           interval: "daily"
       pull-request-branch-name:
           separator: "-"
+      groups:
+          react:
+              patterns:
+                  - "react"
+                  - "react-dom"
+                  - "@types/react"
+                  - "@types/react-dom"


### PR DESCRIPTION
`react` and `react-dom` must be the same version at runtime, but dependabot bumps them in separate PRs, so one can land without the other. That broke im-dev today (#871 bumped `react-dom` alone, causing React error #527, fixed in #877) and has happened before. This groups the react packages so they are always bumped together in a single PR.