### PR TITLE
fix: bring back the deployment stacks widget on the details page

### DIFF
--- a/src/views/instances/details/deployment-details.tsx
+++ b/src/views/instances/details/deployment-details.tsx
@@ -5,6 +5,7 @@ import { Heading } from '../../../components/index.ts'
 import { useDeploymentDetails } from '../../../hooks/index.ts'
 import { DeploymentComponents } from './deployment-components.tsx'
 import styles from './deployment-details.module.css'
+import { DeploymentInstancesList } from './deployment-instances-list.tsx'
 import { DeploymentSummary } from './deployment-summary.tsx'
 
 export const DeploymentDetails: FC = () => {
@@ -41,6 +42,7 @@ export const DeploymentDetails: FC = () => {
                     {!deployment?.instances?.length && (
                         <NoticeBox title="No stacks connected to this instance">Currently you can only add components to an instance when creating one.</NoticeBox>
                     )}
+                    {deployment?.instances?.length > 0 && <DeploymentInstancesList deployment={deployment} loading={loading} />}
                     {deployment?.instances?.length > 0 && <DeploymentComponents deployment={deployment} />}
                 </>
             )}

--- a/src/views/instances/details/deployment-instances-list.tsx
+++ b/src/views/instances/details/deployment-instances-list.tsx
@@ -1,0 +1,57 @@
+import { DataTable, DataTableBody, DataTableCell, DataTableColumnHeader, DataTableHead, DataTableRow } from '@dhis2/ui'
+import type { FC } from 'react'
+import Moment from 'react-moment'
+import { VIEWABLE_INSTANCE_TYPES } from '../../../constants.ts'
+import { Deployment } from '../../../types/index.ts'
+import { Dhis2StackName } from '../new-dhis2/parameter-fieldset.tsx'
+import { StatusLabel } from './status-label.tsx'
+import { ViewInstanceMenuItem } from './view-instance-menu-item.tsx'
+
+/* The stacks a deployment is made of, with the status of each. Operations are not here: they act on
+ * the whole deployment from the list page, or on a single component from the components table. */
+export const DeploymentInstancesList: FC<{
+    deployment: Deployment
+    loading: boolean
+}> = ({ deployment, loading }) => {
+    return (
+        <DataTable>
+            <DataTableHead>
+                <DataTableRow>
+                    <DataTableColumnHeader>Status</DataTableColumnHeader>
+                    <DataTableColumnHeader>Type</DataTableColumnHeader>
+                    <DataTableColumnHeader>Created</DataTableColumnHeader>
+                    <DataTableColumnHeader>Updated</DataTableColumnHeader>
+                    <DataTableColumnHeader></DataTableColumnHeader>
+                </DataTableRow>
+            </DataTableHead>
+            <DataTableBody loading={loading}>
+                {deployment.instances?.map((instance) => {
+                    return (
+                        <tr key={instance.id}>
+                            <DataTableCell staticStyle>
+                                <StatusLabel instanceId={instance.id} />
+                            </DataTableCell>
+                            <DataTableCell staticStyle>{instance.stackName}</DataTableCell>
+                            <DataTableCell staticStyle>
+                                <Moment date={instance.createdAt} fromNow />
+                            </DataTableCell>
+                            <DataTableCell staticStyle>
+                                <Moment date={instance.updatedAt} fromNow />
+                            </DataTableCell>
+                            <DataTableCell staticStyle align="right">
+                                {VIEWABLE_INSTANCE_TYPES.includes(instance.stackName) && (
+                                    <ViewInstanceMenuItem
+                                        group={deployment.group}
+                                        name={instance.name}
+                                        stackName={instance.stackName as Dhis2StackName}
+                                        parameters={instance.parameters}
+                                    />
+                                )}
+                            </DataTableCell>
+                        </tr>
+                    )
+                })}
+            </DataTableBody>
+        </DataTable>
+    )
+}

--- a/src/views/instances/details/status-label.module.css
+++ b/src/views/instances/details/status-label.module.css
@@ -1,0 +1,4 @@
+.wrapper {
+    display: inline-flex;
+    min-width: 75px;
+}

--- a/src/views/instances/details/status-label.tsx
+++ b/src/views/instances/details/status-label.tsx
@@ -1,0 +1,34 @@
+import { CircularLoader, Tag } from '@dhis2/ui'
+import type { FC } from 'react'
+import { useAuthAxios } from '../../../hooks/index.ts'
+import { getTagProps } from '../../../utils/tag.tsx'
+import styles from './status-label.module.css'
+
+type Status = 'NotDeployed' | 'Pending' | 'Booting' | 'Booting (%d)' | 'Running' | 'Error'
+
+const Content: FC<{ status: string; loading: boolean }> = ({ status, loading }) => {
+    if (loading) {
+        return <CircularLoader extrasmall />
+    } else if (status) {
+        return status
+    } else {
+        return 'Unknown'
+    }
+}
+
+export const StatusLabel: FC<{
+    instanceId: number
+}> = ({ instanceId }) => {
+    const [{ data: status, loading }] = useAuthAxios<Status>({
+        method: 'GET',
+        url: `/instances/${instanceId}/status`,
+    })
+
+    return (
+        <span className={styles.wrapper}>
+            <Tag {...getTagProps(status)}>
+                <Content status={status} loading={loading} />
+            </Tag>
+        </span>
+    )
+}

--- a/src/views/instances/details/view-instance-menu-item.tsx
+++ b/src/views/instances/details/view-instance-menu-item.tsx
@@ -1,0 +1,36 @@
+import { Button, IconLaunch16 } from '@dhis2/ui'
+import type { FC } from 'react'
+import { STACK_NAMES } from '../../../constants.ts'
+import { Group } from '../../../types/generated/models/Group.ts'
+import { DeploymentInstanceParameters } from '../../../types/index.ts'
+import { DEPLOY_GLOWROOT } from '../new-dhis2/constants.ts'
+
+type ViewInstanceMenuItemProps = {
+    group: Group
+    name: string
+    stackName: string
+    parameters: DeploymentInstanceParameters
+}
+
+export const ViewInstanceMenuItem: FC<ViewInstanceMenuItemProps> = ({ group, name, stackName, parameters }) => {
+    const basePath = name
+    const instancePath = stackName === STACK_NAMES.PG_ADMIN ? `${basePath}-pgadmin` : basePath
+    const url = `https://${group.hostname}/${instancePath}`
+
+    const glowrootEnabled = stackName === STACK_NAMES.CORE && parameters[DEPLOY_GLOWROOT]?.value === 'true'
+    const glowrootUrl = `https://${group.hostname}/${basePath}-glowroot`
+
+    return (
+        <>
+            <Button small secondary icon={<IconLaunch16 />} onClick={() => window.open(url, '_blank', 'noopener,noreferrer')}>
+                Open
+            </Button>
+            &nbsp;
+            {glowrootEnabled && (
+                <Button small secondary icon={<IconLaunch16 />} onClick={() => window.open(glowrootUrl, '_blank', 'noopener,noreferrer')}>
+                    Glowroot
+                </Button>
+            )}
+        </>
+    )
+}


### PR DESCRIPTION
The table of the stacks a deployment is made of, with the status of each, is back between the summary card and the components widget.

It returns without the three dot menu, which now acts on the whole deployment from the list page, so the widget is the status overview plus the per instance open link.