### PR TITLE
fix: make every replica row and status tag stand on its own

### DIFF
--- a/src/utils/replica-tag.ts
+++ b/src/utils/replica-tag.ts
@@ -1,0 +1,16 @@
+import { InstanceComponentReplica } from '../types/index.ts'
+
+/* One replica's health as Tag colours: a failed pod is negative, a running and ready pod is
+ * positive, anything in between, e.g. pending or not yet ready, is neutral. Shared so the tags on
+ * the deployments list and the rows in the components table cannot disagree about a replica. */
+export const getReplicaTagProps = (replica: InstanceComponentReplica) => {
+    if (replica.phase === 'Failed') {
+        return { negative: true }
+    }
+    if (replica.phase === 'Running' && replica.ready) {
+        return { positive: true }
+    }
+    return { neutral: true }
+}
+
+export const replicaStatusLabel = (replica: InstanceComponentReplica) => (replica.ready ? replica.phase : `${replica.phase} (not ready)`)

--- a/src/views/instances/details/components-table.tsx
+++ b/src/views/instances/details/components-table.tsx
@@ -2,20 +2,11 @@ import { DataTable, DataTableBody, DataTableCell, DataTableColumnHeader, DataTab
 import { Fragment, useState } from 'react'
 import type { FC } from 'react'
 import Moment from 'react-moment'
-import { InstanceComponent, InstanceComponentReplica } from '../../../types/index.ts'
+import { InstanceComponent } from '../../../types/index.ts'
 import { ParameterEntry } from '../../../utils/component-parameters.ts'
+import { getReplicaTagProps, replicaStatusLabel } from '../../../utils/replica-tag.ts'
 import { ComponentOperationsMenu } from './component-operations-menu.tsx'
 import { ComponentParametersTable } from './component-parameters-table.tsx'
-
-const getReplicaTagProps = (replica: InstanceComponentReplica) => {
-    if (replica.phase === 'Failed') {
-        return { negative: true }
-    }
-    if (replica.phase === 'Running' && replica.ready) {
-        return { positive: true }
-    }
-    return { neutral: true }
-}
 
 export const ComponentsTable: FC<{
     instanceId: number
@@ -24,14 +15,16 @@ export const ComponentsTable: FC<{
     parametersByComponent: Record<string, ParameterEntry[]>
     onChanged: () => void
 }> = ({ instanceId, stackName, components, parametersByComponent, onChanged }) => {
-    const [expanded, setExpanded] = useState<string[]>([])
-    const toggle = (component: string) => setExpanded((current) => (current.includes(component) ? current.filter((name) => name !== component) : [...current, component]))
+    /* Keyed per row rather than per component, so expanding one replica of a component does not
+     * expand its siblings and repeat the same parameters underneath each of them. */
+    const [expandedRows, setExpandedRows] = useState<string[]>([])
+    const toggle = (row: string) => setExpandedRows((current) => (current.includes(row) ? current.filter((name) => name !== row) : [...current, row]))
 
     return (
         <DataTable dataTest="instance-components">
             <DataTableHead>
                 <DataTableRow>
-                    {/* Aligns with the expand toggle on the rows that carry component parameters. */}
+                    {/* Aligns with the expand toggle the parameter carrying rows have. */}
                     <DataTableColumnHeader></DataTableColumnHeader>
                     <DataTableColumnHeader>Status</DataTableColumnHeader>
                     <DataTableColumnHeader>Component</DataTableColumnHeader>
@@ -44,60 +37,46 @@ export const ComponentsTable: FC<{
             <DataTableBody>
                 {components.map((component) => {
                     const parameters = parametersByComponent[component.name] ?? []
-                    /* A component's parameters hang off its first row. Rows without a toggle of their
-                     * own, further replicas and components with no parameters, get a filler cell so
-                     * every row stays aligned with the header. */
-                    const expandProps = parameters.length
-                        ? {
-                              expanded: expanded.includes(component.name),
-                              onExpandToggle: () => toggle(component.name),
-                              expandableContent: <ComponentParametersTable parameters={parameters} />,
-                          }
-                        : {}
-
-                    const replicaCells = (replica: InstanceComponentReplica, index: number) => (
-                        <>
-                            <DataTableCell>
-                                <Tag {...getReplicaTagProps(replica)}>{replica.ready ? replica.phase : `${replica.phase} (not ready)`}</Tag>
-                            </DataTableCell>
-                            <DataTableCell>{index === 0 ? component.name : ''}</DataTableCell>
-                            <DataTableCell>{replica.name}</DataTableCell>
-                            <DataTableCell>{replica.restarts}</DataTableCell>
-                            <DataTableCell>
-                                <Moment date={replica.createdAt} fromNow />
-                            </DataTableCell>
-                            <DataTableCell align="right">
-                                {index === 0 && <ComponentOperationsMenu instanceId={instanceId} stackName={stackName} component={component} onChanged={onChanged} />}
-                            </DataTableCell>
-                        </>
-                    )
+                    /* Every row of a component names it, expands to its parameters and offers its
+                     * operations, so a row is never left blank just because a sibling replica came
+                     * first. Components whose stack declares no groups have no parameters to expand,
+                     * and get a filler cell instead of the toggle to stay aligned. */
+                    const rowProps = (row: string) =>
+                        parameters.length
+                            ? {
+                                  expanded: expandedRows.includes(row),
+                                  onExpandToggle: () => toggle(row),
+                                  expandableContent: <ComponentParametersTable parameters={parameters} />,
+                              }
+                            : {}
+                    const operations = <ComponentOperationsMenu instanceId={instanceId} stackName={stackName} component={component} onChanged={onChanged} />
 
                     return (
                         <Fragment key={component.name}>
-                            {component.replicas.map((replica, index) =>
-                                index === 0 ? (
-                                    <DataTableRow key={replica.name} {...expandProps}>
-                                        {parameters.length === 0 && <DataTableCell></DataTableCell>}
-                                        {replicaCells(replica, index)}
-                                    </DataTableRow>
-                                ) : (
-                                    <DataTableRow key={replica.name}>
-                                        <DataTableCell></DataTableCell>
-                                        {replicaCells(replica, index)}
-                                    </DataTableRow>
-                                )
-                            )}
+                            {component.replicas.map((replica) => (
+                                <DataTableRow key={replica.name} {...rowProps(replica.name)}>
+                                    {parameters.length === 0 && <DataTableCell></DataTableCell>}
+                                    <DataTableCell>
+                                        <Tag {...getReplicaTagProps(replica)}>{replicaStatusLabel(replica)}</Tag>
+                                    </DataTableCell>
+                                    <DataTableCell>{component.name}</DataTableCell>
+                                    <DataTableCell>{replica.name}</DataTableCell>
+                                    <DataTableCell>{replica.restarts}</DataTableCell>
+                                    <DataTableCell>
+                                        <Moment date={replica.createdAt} fromNow />
+                                    </DataTableCell>
+                                    <DataTableCell align="right">{operations}</DataTableCell>
+                                </DataTableRow>
+                            ))}
                             {component.replicas.length === 0 && (
-                                <DataTableRow {...expandProps}>
+                                <DataTableRow {...rowProps(component.name)}>
                                     {parameters.length === 0 && <DataTableCell></DataTableCell>}
                                     <DataTableCell></DataTableCell>
                                     <DataTableCell>{component.name}</DataTableCell>
                                     <DataTableCell>No replicas</DataTableCell>
                                     <DataTableCell></DataTableCell>
                                     <DataTableCell></DataTableCell>
-                                    <DataTableCell align="right">
-                                        <ComponentOperationsMenu instanceId={instanceId} stackName={stackName} component={component} onChanged={onChanged} />
-                                    </DataTableCell>
+                                    <DataTableCell align="right">{operations}</DataTableCell>
                                 </DataTableRow>
                             )}
                         </Fragment>

--- a/src/views/instances/list/deployment-component-tags.tsx
+++ b/src/views/instances/list/deployment-component-tags.tsx
@@ -1,24 +1,13 @@
 import { CircularLoader, Tag } from '@dhis2/ui'
 import type { FC } from 'react'
 import { useLiveComponents } from '../../../hooks/index.ts'
-import { InstanceComponent } from '../../../types/index.ts'
+import { getReplicaTagProps } from '../../../utils/replica-tag.ts'
 import styles from './deployment-component-tags.module.css'
 
-const getComponentTagProps = (component: InstanceComponent) => {
-    if (component.replicas.length === 0) {
-        return { neutral: true }
-    }
-    if (component.replicas.some((replica) => replica.phase === 'Failed')) {
-        return { negative: true }
-    }
-    if (component.replicas.every((replica) => replica.ready)) {
-        return { positive: true }
-    }
-    return { neutral: true }
-}
-
-/* One tag per component currently associated with the deployment, across all its instances,
- * colored by the state of the component's replicas in the cluster. */
+/* One tag per replica running for the deployment, across all its instances, labelled with the
+ * component it belongs to and coloured by that replica's own health. A component with several
+ * replicas therefore shows several tags, so one unhealthy replica stays visible instead of being
+ * averaged away, and a component with none still shows as neutral rather than disappearing. */
 export const DeploymentComponentTags: FC<{ deploymentId: number }> = ({ deploymentId }) => {
     const { instances, loading, error } = useLiveComponents(deploymentId)
 
@@ -32,11 +21,19 @@ export const DeploymentComponentTags: FC<{ deploymentId: number }> = ({ deployme
     return (
         <span className={styles.tags}>
             {instances.flatMap((instance) =>
-                instance.components.map((component) => (
-                    <Tag key={`${instance.instanceId}-${component.name}`} {...getComponentTagProps(component)}>
-                        {component.name}
-                    </Tag>
-                ))
+                instance.components.flatMap((component) =>
+                    component.replicas.length === 0
+                        ? [
+                              <Tag key={`${instance.instanceId}-${component.name}`} neutral>
+                                  {component.name}
+                              </Tag>,
+                          ]
+                        : component.replicas.map((replica) => (
+                              <Tag key={`${instance.instanceId}-${component.name}-${replica.name}`} {...getReplicaTagProps(replica)}>
+                                  {component.name}
+                              </Tag>
+                          ))
+                )
             )}
         </span>
     )


### PR DESCRIPTION
Scaling a component to two replicas showed what was wrong with rendering a component once per group of rows: the second replica had a blank component name, no parameters toggle and no operations menu, because all three were rendered only on the first row.

Every replica row now names its component, expands to that component parameters and offers its operations. Expansion is keyed per row, so expanding one replica does not repeat the parameters under its siblings.

On the deployments list a component with several replicas showed one averaged tag, which turned blue and hid that one replica was fine and another was not. There is now one tag per replica, labelled with its component and coloured by that replica health, so an unhealthy replica stays visible. A component with no replicas still shows one neutral tag. The tag colours and the status label are shared with the components table so the two views cannot disagree.