### PR TITLE
chore: stop deploying the EKS dev environment

### DIFF
--- a/helm/data/values/dev/values.yaml
+++ b/helm/data/values/dev/values.yaml
@@ -1,3 +1,8 @@
+# im-dev.dhis2.org is served from the VM control plane in dhis2-sre/dhis2-infrastructure
+# services/im-vm, so this deployment answers on a name that no longer points at EKS. It stays at zero
+# replicas while EKS is being retired, rather than running unreachable beside the one that serves the
+# name. Set back to 1 to roll dev back.
+replicaCount: 0
 image:
   pullPolicy: Always
 tolerations:


### PR DESCRIPTION
`im-dev.dhis2.org` now resolves to the VM control plane in dhis2-sre/dhis2-infrastructure#284, so this deployment answers on a name that no longer reaches it. Every push to master still deploys it, and the chart's `replicaCount: 1` would keep it running unreachable beside the one that serves the name.

`replicaCount: 0` keeps CI from doing that without removing the environment, so rolling dev back during the soak is setting it to 1 again.

Companion to dhis2-sre/im-manager#1657.