### PR TITLE
fix: bump playwright image to v1.62.1 to match package.json

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -23,7 +23,7 @@ services:
       - "3000:3000"
 
   e2e-test:
-    image: mcr.microsoft.com/playwright:v1.60.0-noble
+    image: mcr.microsoft.com/playwright:v1.62.1-noble
     stdin_open: true
     tty: true
     command: >


### PR DESCRIPTION
Dependabot bumped `@playwright/test` to 1.62.1 but the `e2e-test` container in `docker-compose.dev.yml` was still pinned to `mcr.microsoft.com/playwright:v1.60.0-noble`, so the Playwright workflow failed with `Executable doesnt exist at /ms-playwright/chromium_headless_shell-1234/...`. Bump the image to `v1.62.1-noble` to match the package version.