### PR TITLE
fix: link to the file store saved with a database

### DIFF
--- a/src/views/databases/database-details.tsx
+++ b/src/views/databases/database-details.tsx
@@ -2,7 +2,7 @@ import { Button, Card, Center, CircularLoader, DataTable, DataTableBody, DataTab
 import prettyBytes from 'pretty-bytes'
 import { useEffect, useState } from 'react'
 import Moment from 'react-moment'
-import { useNavigate, useParams } from 'react-router-dom'
+import { Link, useNavigate, useParams } from 'react-router-dom'
 import { Heading } from '../../components/index.ts'
 import { useAuthAxios } from '../../hooks/index.ts'
 import { Database } from '../../types/generated/models/Database.ts'
@@ -52,13 +52,14 @@ export const DatabaseDetails = () => {
             ) : undefined,
         },
         {
-            name: 'Filestore ID',
+            name: 'Files',
             value: db.filestoreId ? (
-                <span onClick={() => navigate(`/databases/${db.filestoreId}`)} style={{ cursor: 'pointer', color: 'var(--colors-blue600)', textDecoration: 'underline' }}>
-                    {db.filestore?.name || db.filestoreId}
-                </span>
+                <Link to={`/databases/${db.filestoreId}`}>
+                    {db.filestore?.name ?? `Filestore ${db.filestoreId}`}
+                    {db.filestore?.size ? ` (${prettyBytes(db.filestore.size)})` : ''}
+                </Link>
             ) : (
-                '-'
+                'None saved with this database'
             ),
         },
         { name: 'User', value: db.user?.email },


### PR DESCRIPTION
The database details view showed the file store as a bare numeric id inside a span styled to look like a link, which was not keyboard reachable. It is now a real link reading the file store name and size, or a plain statement when a database was saved without one.

The name and size only arrive once im-manager #1659 is deployed, which fixes the association that resolved a database to itself and starts recording the size. Until then this falls back to naming the file store by its id.