### PR TITLE
feat: open, delete and actions on the details page stacks card

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -11,4 +11,6 @@ export const STACK_NAMES: Record<string, Dhis2StackName> = {
     CHAP_CORE: 'chap-core',
 }
 
-export const VIEWABLE_INSTANCE_TYPES = ['pgadmin', 'dhis2-core']
+/* Stacks that serve something a user can open. The umbrella stacks answer on the deployment's own
+ * address, so they belong here alongside the core stack of the classic composition. */
+export const VIEWABLE_INSTANCE_TYPES = ['pgadmin', 'dhis2-core', 'dhis2', 'dhis2-v2']

--- a/src/views/instances/details/deployment-details.tsx
+++ b/src/views/instances/details/deployment-details.tsx
@@ -10,7 +10,7 @@ import { DeploymentSummary } from './deployment-summary.tsx'
 
 export const DeploymentDetails: FC = () => {
     const navigate = useNavigate()
-    const [{ data: deployment, error, loading }] = useDeploymentDetails()
+    const [{ data: deployment, error, loading }, refetch] = useDeploymentDetails()
     const title = 'Instance details'
 
     return (
@@ -42,7 +42,7 @@ export const DeploymentDetails: FC = () => {
                     {!deployment?.instances?.length && (
                         <NoticeBox title="No stacks connected to this instance">Currently you can only add components to an instance when creating one.</NoticeBox>
                     )}
-                    {deployment?.instances?.length > 0 && <DeploymentInstancesList deployment={deployment} loading={loading} />}
+                    {deployment?.instances?.length > 0 && <DeploymentInstancesList deployment={deployment} loading={loading} refetch={() => void refetch()} />}
                     {deployment?.instances?.length > 0 && <DeploymentComponents deployment={deployment} />}
                 </>
             )}

--- a/src/views/instances/details/deployment-instances-list.tsx
+++ b/src/views/instances/details/deployment-instances-list.tsx
@@ -1,23 +1,29 @@
-import { DataTable, DataTableBody, DataTableCell, DataTableColumnHeader, DataTableHead, DataTableRow } from '@dhis2/ui'
+import { ButtonStrip, DataTable, DataTableBody, DataTableCell, DataTableColumnHeader, DataTableHead, DataTableRow } from '@dhis2/ui'
 import type { FC } from 'react'
 import Moment from 'react-moment'
+import { useNavigate } from 'react-router-dom'
 import { VIEWABLE_INSTANCE_TYPES } from '../../../constants.ts'
 import { Deployment } from '../../../types/index.ts'
+import { DeleteButton } from '../list/delete-menu-button.tsx'
+import { DeploymentActionsMenu } from '../list/deployment-actions-menu.tsx'
 import { Dhis2StackName } from '../new-dhis2/parameter-fieldset.tsx'
-import { StatusLabel } from './status-label.tsx'
 import { ViewInstanceMenuItem } from './view-instance-menu-item.tsx'
 
-/* The stacks a deployment is made of, with the status of each. Operations are not here: they act on
- * the whole deployment from the list page, or on a single component from the components table. */
+/* The stacks a deployment is made of. Status is not here: the components table below owns it, down to
+ * the individual replica, so a single stack-wide status could only repeat it or disagree with it.
+ * Open resolves the stack's own address, while delete and the actions menu act on the whole
+ * deployment, the same three buttons as on the instances list. */
 export const DeploymentInstancesList: FC<{
     deployment: Deployment
     loading: boolean
-}> = ({ deployment, loading }) => {
+    refetch: () => void
+}> = ({ deployment, loading, refetch }) => {
+    const navigate = useNavigate()
+
     return (
         <DataTable>
             <DataTableHead>
                 <DataTableRow>
-                    <DataTableColumnHeader>Status</DataTableColumnHeader>
                     <DataTableColumnHeader>Type</DataTableColumnHeader>
                     <DataTableColumnHeader>Created</DataTableColumnHeader>
                     <DataTableColumnHeader>Updated</DataTableColumnHeader>
@@ -28,9 +34,6 @@ export const DeploymentInstancesList: FC<{
                 {deployment.instances?.map((instance) => {
                     return (
                         <tr key={instance.id}>
-                            <DataTableCell staticStyle>
-                                <StatusLabel instanceId={instance.id} />
-                            </DataTableCell>
                             <DataTableCell staticStyle>{instance.stackName}</DataTableCell>
                             <DataTableCell staticStyle>
                                 <Moment date={instance.createdAt} fromNow />
@@ -39,14 +42,18 @@ export const DeploymentInstancesList: FC<{
                                 <Moment date={instance.updatedAt} fromNow />
                             </DataTableCell>
                             <DataTableCell staticStyle align="right">
-                                {VIEWABLE_INSTANCE_TYPES.includes(instance.stackName) && (
-                                    <ViewInstanceMenuItem
-                                        group={deployment.group}
-                                        name={instance.name}
-                                        stackName={instance.stackName as Dhis2StackName}
-                                        parameters={instance.parameters}
-                                    />
-                                )}
+                                <ButtonStrip>
+                                    {VIEWABLE_INSTANCE_TYPES.includes(instance.stackName) && (
+                                        <ViewInstanceMenuItem
+                                            group={deployment.group}
+                                            name={instance.name}
+                                            stackName={instance.stackName as Dhis2StackName}
+                                            parameters={instance.parameters}
+                                        />
+                                    )}
+                                    <DeleteButton id={deployment.id} displayName={deployment.name} onComplete={() => navigate('/instances')} />
+                                    <DeploymentActionsMenu deployment={deployment} refetch={refetch} />
+                                </ButtonStrip>
                             </DataTableCell>
                         </tr>
                     )


### PR DESCRIPTION
On the instance details page the stacks card now shows Type, Created, Updated and the same three buttons as the instances list: Open, Delete and the actions menu.

The status column is gone. The components table directly below reports status per replica, so a single stack-wide status could only repeat that or contradict it.

Open resolves each stack's own address, so a pgadmin row still opens pgadmin. It now also covers the umbrella stacks: `VIEWABLE_INSTANCE_TYPES` only listed `pgadmin` and `dhis2-core`, which is why a `dhis2-v2` deployment showed no Open button at all.

Delete and the actions menu act on the whole deployment, matching the instances list, and deleting navigates back to the list since the deployment it was showing is gone. Note this means a deployment composed of several stacks repeats those two buttons per row; say the word and I can render them once instead.