### PR TITLE
fix: reconnect the event stream instead of going quiet

### DIFF
--- a/src/hooks/use-auth-axios.ts
+++ b/src/hooks/use-auth-axios.ts
@@ -28,7 +28,7 @@ const axiosInstance = createAxiosInstance()
 
 let refreshInFlight: Promise<unknown> | null = null
 
-const refreshTokens = () => {
+export const refreshTokens = () => {
     if (!refreshInFlight) {
         refreshInFlight = createAxiosInstance()
             .post<RefreshTokenRequest>('/refresh', null, { headers: { 'Content-Type': 'application/json' } })

--- a/src/hooks/use-live-components.ts
+++ b/src/hooks/use-live-components.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { ComponentStatusEventData, DeploymentInstanceComponents } from '../types/index.ts'
 import { useAuthAxios } from './use-auth-axios.ts'
 import { useNotificationsContext } from './use-notifications-context.ts'
@@ -36,12 +36,24 @@ export const useLiveComponents = (deploymentId: number) => {
         { url: `/deployments/${deploymentId}/components` },
         { useCache: false, autoCatch: true }
     )
-    const { lastComponentStatus } = useNotificationsContext()
+    const { lastComponentStatus, streamEpoch } = useNotificationsContext()
     const [instances, setInstances] = useState<DeploymentInstanceComponents[] | undefined>(undefined)
 
     useEffect(() => {
         setInstances(data)
     }, [data])
+
+    /* Transitions during a gap in the stream, including the gap before it first opens, are never
+     * pushed, so reload whenever it comes up rather than leave a view that quietly stopped moving. */
+    const connectedEpoch = useRef(streamEpoch)
+    useEffect(() => {
+        if (streamEpoch === connectedEpoch.current) {
+            return
+        }
+        connectedEpoch.current = streamEpoch
+        refetch()
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [streamEpoch])
 
     useEffect(() => {
         if (!lastComponentStatus || lastComponentStatus.data.deploymentId !== deploymentId) {

--- a/src/hooks/use-notifications.ts
+++ b/src/hooks/use-notifications.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { ComponentStatusEventData } from '../types/index.ts'
-import { baseURL, useAuthAxios } from './use-auth-axios.ts'
+import { baseURL, refreshTokens, useAuthAxios } from './use-auth-axios.ts'
 
 export type DatabaseSaveData = {
     status: 'started' | 'success' | 'error'
@@ -34,10 +34,16 @@ export type SseEvent = {
     data: DatabaseSaveData
 }
 
+const STREAM_RECONNECT_DELAY_MS = 3_000
+const STREAM_RECONNECT_MAX_DELAY_MS = 30_000
+
 export const useNotifications = () => {
     const [notifications, setNotifications] = useState<Notification[]>([])
     const [lastSseEvent, setLastSseEvent] = useState<SseEvent | null>(null)
     const [lastComponentStatus, setLastComponentStatus] = useState<ComponentStatusEvent | null>(null)
+    /* Counts the times the event stream has come up. Consumers watch it to reload what they cannot
+     * have been told about while it was down. */
+    const [streamEpoch, setStreamEpoch] = useState(0)
     const componentStatusSeq = useRef(0)
 
     const [, fetchNotifications] = useAuthAxios<Notification[]>('/notifications', { manual: true, autoCatch: true })
@@ -61,7 +67,10 @@ export const useNotifications = () => {
     }, [refresh])
 
     useEffect(() => {
-        const es = new EventSource(`${baseURL}/events`, { withCredentials: true })
+        let unmounted = false
+        let source: EventSource | null = null
+        let reconnect: ReturnType<typeof setTimeout> | undefined
+        let delay = STREAM_RECONNECT_DELAY_MS
 
         const makeHandler = (kind: NotificationKind) => (e: MessageEvent) => {
             try {
@@ -75,21 +84,63 @@ export const useNotifications = () => {
             }
         }
 
-        es.onerror = (err) => console.error('[notifications] EventSource error', err)
-        es.onopen = () => refreshRef.current()
+        const connect = () => {
+            const es = new EventSource(`${baseURL}/events`, { withCredentials: true })
+            source = es
 
-        es.addEventListener('database-save', makeHandler('database-save'))
-        es.addEventListener('filestore-backup', makeHandler('filestore-backup'))
-        es.addEventListener('component-status', (e: MessageEvent) => {
-            try {
-                const data = JSON.parse(e.data) as ComponentStatusEventData
-                componentStatusSeq.current += 1
-                setLastComponentStatus({ seq: componentStatusSeq.current, data })
-            } catch (err) {
-                console.error('[notifications] failed to parse component-status event', { raw: e.data, err })
+            es.onopen = () => {
+                delay = STREAM_RECONNECT_DELAY_MS
+                /* Anything that happened while the stream was down was never pushed, so consumers
+                 * reload rather than carry on from a view that stopped being live. */
+                setStreamEpoch((current) => current + 1)
+                refreshRef.current()
             }
-        })
-        return () => es.close()
+
+            /* EventSource reconnects on its own when an established stream drops, but an HTTP error
+             * response closes it for good. The access token lives five minutes while a connection
+             * lives much longer, so a reconnect regularly meets an expired cookie and gets a 401,
+             * which would silently end live updates until the page is reloaded. Refresh the session
+             * and dial back in, backing off so a genuinely dead session does not spin. */
+            es.onerror = () => {
+                if (unmounted || es.readyState !== EventSource.CLOSED) {
+                    return
+                }
+                es.close()
+                const wait = delay
+                delay = Math.min(delay * 2, STREAM_RECONNECT_MAX_DELAY_MS)
+                reconnect = setTimeout(() => {
+                    if (unmounted) {
+                        return
+                    }
+                    refreshTokens()
+                        .catch((err) => console.error('[notifications] failed to refresh the session before reconnecting', err))
+                        .then(() => {
+                            if (!unmounted) {
+                                connect()
+                            }
+                        })
+                }, wait)
+            }
+
+            es.addEventListener('database-save', makeHandler('database-save'))
+            es.addEventListener('filestore-backup', makeHandler('filestore-backup'))
+            es.addEventListener('component-status', (e: MessageEvent) => {
+                try {
+                    const data = JSON.parse(e.data) as ComponentStatusEventData
+                    componentStatusSeq.current += 1
+                    setLastComponentStatus({ seq: componentStatusSeq.current, data })
+                } catch (err) {
+                    console.error('[notifications] failed to parse component-status event', { raw: e.data, err })
+                }
+            })
+        }
+
+        connect()
+        return () => {
+            unmounted = true
+            clearTimeout(reconnect)
+            source?.close()
+        }
     }, [])
 
     const markRead = useCallback(
@@ -107,5 +158,5 @@ export const useNotifications = () => {
 
     const unreadCount = notifications.filter((n) => !n.read).length
 
-    return { notifications, unreadCount, lastSseEvent, lastComponentStatus, markRead, markAllRead }
+    return { notifications, unreadCount, lastSseEvent, lastComponentStatus, streamEpoch, markRead, markAllRead }
 }


### PR DESCRIPTION
Component status only moved when the refresh button was pressed because the page had no event stream left.

An EventSource retries a stream that drops mid-flight, but an HTTP error response closes it permanently. The access token cookie lives five minutes while a connection lives far longer, so reconnects regularly met an expired cookie and got a 401. From that point the page received nothing, with only a console error to show for it.

Observed on version-3-0 for one browser over a single morning: connections held 298s, 3603s and 1139s, each followed by a 401, and after one of those 401s the page made no further attempt for 55 minutes. A restart during that window pushed five events onto the stream that the page never saw.

The stream now refreshes the session and dials back in with a capped backoff. Consumers also reload on every reconnect, since transitions during the gap were never pushed and merging would otherwise resume from a stale view.

Not addressed here: the connection dropping at almost exactly the token lifetime is unexplained, and worth a look on the backend. The reconnect makes it self-healing either way.